### PR TITLE
Removed BlockchainGeneration.IntegrationTests and the BlockGenerator feature 

### DIFF
--- a/src/Enigma.sln
+++ b/src/Enigma.sln
@@ -34,13 +34,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Features.Ge
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Features.BlockchainGeneration", "Stratis.Sidechains.Features.BlockchainGeneration\Stratis.Sidechains.Features.BlockchainGeneration.csproj", "{3DEB5772-3918-483E-8B6B-7BDD9AA6B6B9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Features.BlockchainGeneration.IntegrationTests", "Stratis.Sidechains.Features.BlockchainGeneration.IntegrationTests\Stratis.Sidechains.Features.BlockchainGeneration.IntegrationTests.csproj", "{0B889C55-6F30-48CC-B51E-F635F8644B28}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Features.BlockchainGeneration.Tests", "Stratis.Sidechains.Features.BlockchainGeneration.Tests\Stratis.Sidechains.Features.BlockchainGeneration.Tests.csproj", "{08C42E76-2A9F-4E00-80A5-8AFDB3FE71A8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Features.BlockchainGeneration.Tests.Common", "Stratis.Sidechains.Features.BlockchainGeneration.Tests.Common\Stratis.Sidechains.Features.BlockchainGeneration.Tests.Common.csproj", "{1427DE3A-A0E9-4C35-A095-DD686025F923}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Features.BlockGenerator", "Stratis.Sidechains.Features.BlockGenerator\Stratis.Sidechains.Features.BlockGenerator.csproj", "{D5FC8EBA-7DDE-47DD-B12A-80A46AC8C846}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.FederatedSidechains.Initialisation", "Stratis.FederatedSidechains.Initialisation\Stratis.FederatedSidechains.Initialisation.csproj", "{3526B5DB-8E08-445F-9DCE-65566491D94F}"
 EndProject
@@ -106,10 +102,6 @@ Global
 		{3DEB5772-3918-483E-8B6B-7BDD9AA6B6B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3DEB5772-3918-483E-8B6B-7BDD9AA6B6B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3DEB5772-3918-483E-8B6B-7BDD9AA6B6B9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0B889C55-6F30-48CC-B51E-F635F8644B28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0B889C55-6F30-48CC-B51E-F635F8644B28}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0B889C55-6F30-48CC-B51E-F635F8644B28}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0B889C55-6F30-48CC-B51E-F635F8644B28}.Release|Any CPU.Build.0 = Release|Any CPU
 		{08C42E76-2A9F-4E00-80A5-8AFDB3FE71A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{08C42E76-2A9F-4E00-80A5-8AFDB3FE71A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08C42E76-2A9F-4E00-80A5-8AFDB3FE71A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -118,10 +110,6 @@ Global
 		{1427DE3A-A0E9-4C35-A095-DD686025F923}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1427DE3A-A0E9-4C35-A095-DD686025F923}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1427DE3A-A0E9-4C35-A095-DD686025F923}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D5FC8EBA-7DDE-47DD-B12A-80A46AC8C846}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D5FC8EBA-7DDE-47DD-B12A-80A46AC8C846}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D5FC8EBA-7DDE-47DD-B12A-80A46AC8C846}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D5FC8EBA-7DDE-47DD-B12A-80A46AC8C846}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3526B5DB-8E08-445F-9DCE-65566491D94F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3526B5DB-8E08-445F-9DCE-65566491D94F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3526B5DB-8E08-445F-9DCE-65566491D94F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Stratis.SidechainD/Program.cs
+++ b/src/Stratis.SidechainD/Program.cs
@@ -15,7 +15,6 @@ using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Utilities;
 using Stratis.FederatedPeg.Features.SidechainGeneratorServices;
 using Stratis.Sidechains.Features.BlockchainGeneration;
-using Stratis.Sidechains.Features.BlockGenerator;
 
 namespace Stratis.SidechainD
 {
@@ -99,7 +98,6 @@ namespace Stratis.SidechainD
                       .UseMempool()
                       .UseWallet()
                       .AddPowPosMining()
-                      .UseBlockGenerator()
                       .UseApi()
                       .AddRPC()
                       .UseSidechains()

--- a/src/Stratis.SidechainD/Stratis.SidechainD.csproj
+++ b/src/Stratis.SidechainD/Stratis.SidechainD.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Stratis.FederatedPeg.Features.SidechainGeneratorServices\Stratis.FederatedPeg.Features.SidechainGeneratorServices.csproj" />
-    <ProjectReference Include="..\Stratis.Sidechains.Features.BlockGenerator\Stratis.Sidechains.Features.BlockGenerator.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* The premine test should go into the full node.

* Removed the BlockGenerator feature as mining happen automatically when setting -mine, and there's no need to generate blocks manually.