### PR TITLE
Ensure all nodes get the CounterChainTransactionId

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/CounterChain/CounterChainSessionManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/CounterChain/CounterChainSessionManager.cs
@@ -225,6 +225,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.CounterChain
 
             if (counterChainSession == null)
             {
+                var exists = this.sessions.TryGetValue(sessionId, out counterChainSession);
+                if (exists) return counterChainSession.CounterChainTransactionId;
                 throw new InvalidOperationException($"No CounterChainSession found in the counter chain for session id {sessionId}.");
             }
             this.MarkSessionAsSigned(counterChainSession);


### PR DESCRIPTION
The boss node is not propagating the CounterChainTransactionId back to its monitor chain.  The boss node is not completing its session and has a CounterChainTransactionId of 00000000000000000000000000000000000000000.

This happens because the code is correctly stopping the session if it has already signed its partial transaction.

This change bypasses that check to get the required Id.

It's a minimum change at this late stage.