### PR TITLE
upgrades libraries

### DIFF
--- a/src/FedKeyPairGen/FedKeyPairGen.csproj
+++ b/src/FedKeyPairGen/FedKeyPairGen.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NStratis" Version="4.0.0.65" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="1.2.1-beta" />
+    <PackageReference Include="NStratis" Version="4.0.0.67" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="1.2.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FederatedPeg.sln
+++ b/src/FederatedPeg.sln
@@ -17,8 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.FederatedSidechains
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.SidechainD", "Stratis.SidechainD\Stratis.SidechainD.csproj", "{C3FF2EF8-50B6-43D8-AC78-BCFEBF7DE394}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.FederatedSidechains.IntegrationTests", "Stratis.FederatedSidechains.IntegrationTests\Stratis.FederatedSidechains.IntegrationTests.csproj", "{0C1E95D8-5048-4660-85F8-58BB303897AE}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Sidechains.Networks", "Stratis.Sidechains.Networks\Stratis.Sidechains.Networks.csproj", "{C5D390A9-1E08-47DE-BAAB-0AA9FC69CCC2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{EEF9F276-23FB-4CC2-AF47-0E646EB2F6F1}"
@@ -59,10 +57,6 @@ Global
 		{C3FF2EF8-50B6-43D8-AC78-BCFEBF7DE394}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3FF2EF8-50B6-43D8-AC78-BCFEBF7DE394}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3FF2EF8-50B6-43D8-AC78-BCFEBF7DE394}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0C1E95D8-5048-4660-85F8-58BB303897AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C1E95D8-5048-4660-85F8-58BB303897AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0C1E95D8-5048-4660-85F8-58BB303897AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0C1E95D8-5048-4660-85F8-58BB303897AE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C5D390A9-1E08-47DE-BAAB-0AA9FC69CCC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C5D390A9-1E08-47DE-BAAB-0AA9FC69CCC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5D390A9-1E08-47DE-BAAB-0AA9FC69CCC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -76,7 +70,6 @@ Global
 		{C08CA036-D47D-40CF-83E3-F09EF5EC7515} = {EEF9F276-23FB-4CC2-AF47-0E646EB2F6F1}
 		{3526B5DB-8E08-445F-9DCE-65566491D94F} = {4B9DEF95-A336-404B-908D-E1BFA1DB2DA9}
 		{3D106928-3A8E-4EB1-9F9A-45856DBAA16B} = {EEF9F276-23FB-4CC2-AF47-0E646EB2F6F1}
-		{0C1E95D8-5048-4660-85F8-58BB303897AE} = {EEF9F276-23FB-4CC2-AF47-0E646EB2F6F1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {034BDA2C-1CEE-4128-B444-CE1D425CB11C}

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Stratis.FederatedPeg.Features.FederationGateway.csproj
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Stratis.FederatedPeg.Features.FederationGateway.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stratis.Bitcoin" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Notifications" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="1.2.1-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Notifications" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="1.2.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.FederatedPeg.Tests/IPEndPointComparerTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/IPEndPointComparerTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using DBreeze.Utils;
+﻿using System.Net;
 using FluentAssertions;
 using Stratis.FederatedPeg.Features.FederationGateway.NetworkHelpers;
 using Xunit;

--- a/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
+++ b/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
@@ -18,14 +18,14 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NStratis" Version="4.0.0.65" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NStratis" Version="4.0.0.67" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="Stratis.Bitcoin" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="1.2.1-beta" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="1.2.3-beta" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.FederatedSidechains.Initialisation.Tests/Stratis.FederatedSidechains.Initialisation.Tests.csproj
+++ b/src/Stratis.FederatedSidechains.Initialisation.Tests/Stratis.FederatedSidechains.Initialisation.Tests.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Stratis.FederatedSidechains.IntegrationTests/Stratis.FederatedSidechains.IntegrationTests.csproj
+++ b/src/Stratis.FederatedSidechains.IntegrationTests/Stratis.FederatedSidechains.IntegrationTests.csproj
@@ -10,11 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Stratis.Bitcoin.IntegrationTests.Common" Version="1.1.13-beta" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Stratis.Bitcoin.IntegrationTests.Common" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Tests.Common" Version="1.2.3-beta" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.FederationGatewayD/Stratis.FederationGatewayD.csproj
+++ b/src/Stratis.FederationGatewayD/Stratis.FederationGatewayD.csproj
@@ -14,14 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stratis.Bitcoin" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.RPC" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="1.2.1-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.RPC" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="1.2.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.SidechainD/Stratis.SidechainD.csproj
+++ b/src/Stratis.SidechainD/Stratis.SidechainD.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stratis.Bitcoin" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="1.2.1-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="1.2.1-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="1.2.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="1.2.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.Sidechains.Networks/ApexMain.cs
+++ b/src/Stratis.Sidechains.Networks/ApexMain.cs
@@ -5,6 +5,7 @@ using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Networks;
 using NBitcoin.Protocol;
 using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -46,13 +47,15 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new BIP9DeploymentsArray();
+            var bip9Deployments = new StratisBIP9Deployments();
 
             var consensusOptions = new ConsensusOptions(
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
-                maxBlockSigopsCost: 20_000);
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5
+            );
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/ApexRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/ApexRegTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Protocol;
+using Stratis.Bitcoin.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -44,13 +45,15 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new BIP9DeploymentsArray();
+            var bip9Deployments = new StratisBIP9Deployments();
 
             var consensusOptions = new ConsensusOptions(
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
-                maxBlockSigopsCost: 20_000);
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5
+            );
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/ApexTest.cs
+++ b/src/Stratis.Sidechains.Networks/ApexTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.Protocol;
+using Stratis.Bitcoin.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -43,13 +44,15 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new BIP9DeploymentsArray();
+            var bip9Deployments = new StratisBIP9Deployments();
 
             var consensusOptions = new ConsensusOptions(
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
                 maxStandardTxWeight: 100_000,
-                maxBlockSigopsCost: 20_000);
+                maxBlockSigopsCost: 20_000,
+                maxStandardTxSigopsCost: 20_000 / 5
+            );
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
+++ b/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NStratis" Version="4.0.0.65" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="1.2.1-beta" />
+    <PackageReference Include="NStratis" Version="4.0.0.67" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="1.2.3-beta" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Stratis.Bitcoin.* 1.2.3-beta
NStratis 4.0.0.67
Microsoft.NET.Test.Sdk 15.9.0
Xunit 2.4.1

That meant removing unused Integration test project which used corrupted Stratis.Bitcoin.IntegrationTests.Common temporarily