### PR TITLE
Deterministic creation of target transactions

### DIFF
--- a/requirements/cross-chain-transfer.md
+++ b/requirements/cross-chain-transfer.md
@@ -95,7 +95,7 @@ It may be that in order to use a multisig UTXO the algorithm will require it to 
 
 **The structure of the outputs of the transaction:**
 
-- The first output returns change (if any) back to the multisig, and appears after the value transfer output.
+- The first output returns change (if any) back to the multisig.
 - The second output is the one corresponding to the actual transfer of coins. It transfers the amount found on chain A deposits (val<sub>1</sub> or val<sub>2</sub> on the diagrams) to the corresponding chain B address (i.e. the scriptPubKey) found in the OP_RETURN of the chain A deposits made to the multisig (add<sub>1</sub> or add<sub>2</sub> on the diagram) 
 - An OP_RETURN output containing the transaction id of the deposit to the federation's multisig on the originating chain (id<sub>1</sub> or id<sub>2</sub> on the diagram).
 

--- a/requirements/cross-chain-transfer.md
+++ b/requirements/cross-chain-transfer.md
@@ -83,7 +83,7 @@ It may be that in order to use a multisig UTXO the algorithm will require it to 
 **The algorithm to select UTXOs for a transfer:**
 
 - The oldest UTXO (determined by block height) is selected first.
-- If a block has more than one UTXO, then they are selected in order of appearance in the block transaction list.
+- If a block has more than one UTXO, then they are selected in order of transaction id.
 - If multiple UTXOs appear within a transaction then they are selected in ascending index order.
 - Dusty UTXOs are ignored (below 100 Strats ?).
 - When change is non-null and below dust level (100 Strats ?), the next UTXOs needed to build up a change value above that level are also selected.
@@ -95,8 +95,8 @@ It may be that in order to use a multisig UTXO the algorithm will require it to 
 
 **The structure of the outputs of the transaction:**
 
-- The first output is the one corresponding to the actual transfer of coins. It transfers the amount found on chain A deposits (val<sub>1</sub> or val<sub>2</sub> on the diagrams) to the corresponding chain B address (i.e. the scriptPubKey) found in the OP_RETURN of the chain A deposits made to the multisig (add<sub>1</sub> or add<sub>2</sub> on the diagram) 
-- The second output returns change (if any) back to the multisig, and appears after the value transfer output.
+- The first output returns change (if any) back to the multisig, and appears after the value transfer output.
+- The second output is the one corresponding to the actual transfer of coins. It transfers the amount found on chain A deposits (val<sub>1</sub> or val<sub>2</sub> on the diagrams) to the corresponding chain B address (i.e. the scriptPubKey) found in the OP_RETURN of the chain A deposits made to the multisig (add<sub>1</sub> or add<sub>2</sub> on the diagram) 
 - An OP_RETURN output containing the transaction id of the deposit to the federation's multisig on the originating chain (id<sub>1</sub> or id<sub>2</sub> on the diagram).
 
 A member that comes back online after a long period will need to sync both chains and also build the database of transfer transactions, they should be able to do this simply by looking at the chains themselves.  

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
@@ -342,7 +342,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
                     throw new WalletException("Reorg");
                 }
 
-                // The block coming in to the wallet should never be ahead of the wallet. 
+                // The block coming in to the wallet should never be ahead of the wallet.
                 // If the block is behind, let it pass.
                 if (chainedHeader.Height > current.Height)
                 {
@@ -429,7 +429,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
                             return true;
 
                         // Include the keys that are in the wallet but that are for receiving
-                        // addresses (which would mean the user paid itself). 
+                        // addresses (which would mean the user paid itself).
                         // We also exclude the keys involved in a staking transaction.
                         //return !addr.IsChangeAddress() && !transaction.IsCoinStake;
                         return true;
@@ -443,7 +443,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
             // Figure out what to do when this transaction is found to affect the wallet.
             if (foundSendingTrx || foundReceivingTrx)
             {
-                // Save the wallet when the transaction was not included in a block. 
+                // Save the wallet when the transaction was not included in a block.
                 if (blockHeight == null)
                 {
                     this.SaveWallet();
@@ -718,7 +718,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
         /// </summary>
         /// <returns>The wallet object that was saved into the file system.</returns>
         /// <exception cref="WalletException">Thrown if wallet cannot be created.</exception>
-        private FederationWallet GenerateWallet()
+        public FederationWallet GenerateWallet()
         {
             this.logger.LogTrace("Generating the federation wallet file.");
 

--- a/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
+++ b/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="NStratis" Version="4.0.0.67" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Stratis.Bitcoin" Version="1.2.3-beta" />

--- a/src/Stratis.FederatedPeg.Tests/TransactionBuilderTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/TransactionBuilderTests.cs
@@ -1,0 +1,169 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using NSubstitute;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Utilities;
+using Stratis.FederatedPeg.Features.FederationGateway;
+using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
+using Stratis.FederatedPeg.Features.FederationGateway.Wallet;
+using Stratis.Sidechains.Networks;
+using Xunit;
+using Recipient = Stratis.FederatedPeg.Features.FederationGateway.Wallet;
+
+namespace Stratis.FederatedPeg.Tests
+{
+    /// <summary>
+    /// Tests whether transactions are built deterministically.
+    /// </summary>
+    public class TransactionBuilderTests
+    {
+        private Network network;
+        private IDateTimeProvider dateTimeProvider;
+        private ILoggerFactory loggerFactory;
+        private IFederationGatewaySettings settings;
+        private IFederationWalletManager federationWalletManager;
+        private IFederationWalletManager federationWalletManager2;
+        private IFederationWalletTransactionHandler federationTransactionHandler;
+        private ConcurrentChain chain;
+        private NodeSettings nodeSettings;
+        private DataFolder dataFolder;
+        private IWalletFeePolicy walletFeePolicy;
+        private FederationWallet wallet;
+
+        public TransactionBuilderTests()
+        {
+            this.network = ApexNetwork.RegTest;
+            this.nodeSettings = new NodeSettings(this.network, NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION,
+                args: new[] {
+                    "-redeemscript=2 026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c 02a97b7d0fad7ea10f456311dcd496ae9293952d4c5f2ebdfc32624195fde14687 02e9d3cd0c2fa501957149ff9d21150f3901e6ece0e3fe3007f2372720c84e3ee1 03c99f997ed71c7f92cf532175cea933f2f11bf08f1521d25eb3cc9b8729af8bf4 034b191e3b3107b71d1373e840c5bf23098b55a355ca959b968993f5dec699fc38 5 OP_CHECKMULTISIG",
+                    "-publickey=026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c"
+                });
+            this.loggerFactory = Substitute.For<ILoggerFactory>();
+            this.settings = new FederationGatewaySettings(this.nodeSettings);
+            this.chain = new ConcurrentChain(this.network);
+            this.dataFolder = this.nodeSettings.DataFolder;
+            var mockWalletFeePolicy = new Mock<IWalletFeePolicy>();
+            this.walletFeePolicy = mockWalletFeePolicy.Object;
+            this.dateTimeProvider = DateTimeProvider.Default;
+
+            // Create the wallet manager.
+            this.federationWalletManager = new FederationWalletManager(
+                this.loggerFactory,
+                this.network,
+                this.chain,
+                this.nodeSettings,
+                this.dataFolder,
+                this.walletFeePolicy,
+                new Mock<IAsyncLoopFactory>().Object,
+                new NodeLifetime(),
+                this.dateTimeProvider,
+                this.settings);
+
+            // Create the wallet.
+            this.wallet = (this.federationWalletManager as FederationWalletManager).GenerateWallet();
+
+            var mockFederationWalletManager = new Mock<IFederationWalletManager>();
+
+            // Return the mock wallet.
+            mockFederationWalletManager.Setup(s => s.GetWallet()).Returns(this.wallet);
+
+            // Mock funds in wallet.
+            mockFederationWalletManager.Setup(s => s.GetSpendableTransactionsInWallet(It.IsAny<int>())).Returns(new[]
+            {
+                new UnspentOutputReference()
+                {
+                    Transaction = new TransactionData()
+                    {
+                        Amount = Money.COIN * 90,
+                        Id = new uint256(1),
+                        Index = 0,
+                        ScriptPubKey = this.wallet.MultiSigAddress.ScriptPubKey,
+                        BlockHeight = 2
+                    }
+                },
+                new UnspentOutputReference()
+                {
+                    Transaction = new TransactionData()
+                    {
+                        Amount = Money.COIN * 80,
+                        Id = new uint256(1),
+                        Index = 1,
+                        ScriptPubKey = this.wallet.MultiSigAddress.ScriptPubKey,
+                        BlockHeight = 2
+                    }
+                },
+                new UnspentOutputReference()
+                {
+                    Transaction = new TransactionData()
+                    {
+                        Amount = Money.COIN * 70,
+                        Id = new uint256(2),
+                        Index = 0,
+                        ScriptPubKey = this.wallet.MultiSigAddress.ScriptPubKey,
+                        BlockHeight = 3
+                    }
+                }
+            });
+
+            this.federationWalletManager2 = mockFederationWalletManager.Object;
+            this.federationTransactionHandler = new FederationWalletTransactionHandler(this.loggerFactory, this.federationWalletManager2, this.walletFeePolicy, this.network);
+        }
+
+        [Fact]
+        public void BuildTransactionBuildsDeterministicTransactions()
+        {
+            MultiSigAddress multiSigAddress = this.wallet.MultiSigAddress;
+            var recipients = new List<Recipient.Recipient>()
+            {
+                new Recipient.Recipient
+                {
+                    Amount = Money.COIN * 160,
+                    ScriptPubKey = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(new Key().PubKey.Hash)
+                }
+            };
+
+            int blockHeight = this.chain.Height;
+            string opReturnData = blockHeight.ToString();
+
+            // Build the multisig transaction template.
+            var multiSigContext = new TransactionBuildContext(recipients, opReturnData: Encoding.UTF8.GetBytes(opReturnData))
+            {
+                TransactionFee = Money.Coins(0.01m),
+                MinConfirmations = 1,
+                Shuffle = false,
+                MultiSig = multiSigAddress,
+                IgnoreVerify = true,
+                Sign = false
+            };
+
+            // Build the transaction.
+            Transaction transaction = this.federationTransactionHandler.BuildTransaction(multiSigContext);
+
+            // Transactions inputs.
+            Assert.Equal(2, transaction.Inputs.Count);
+            Assert.Equal((uint256)1, transaction.Inputs[0].PrevOut.Hash);
+            Assert.Equal((uint)0, transaction.Inputs[0].PrevOut.N);
+            Assert.Equal((uint256)1, transaction.Inputs[1].PrevOut.Hash);
+            Assert.Equal((uint)1, transaction.Inputs[1].PrevOut.N);
+
+            // Transaction outputs.
+            Assert.Equal(3, transaction.Outputs.Count);
+
+            // Transaction output value - change.
+            Assert.Equal(new Money(9.99m, MoneyUnit.BTC), transaction.Outputs[0].Value);
+            Assert.Equal(multiSigAddress.ScriptPubKey, transaction.Outputs[0].ScriptPubKey);
+
+            // Transaction output value - recipient.
+            Assert.Equal(new Money(160m, MoneyUnit.BTC), transaction.Outputs[1].Value);
+            Assert.Equal(recipients[0].ScriptPubKey, transaction.Outputs[1].ScriptPubKey);
+
+            // Transaction output value - op_return.
+            Assert.Equal(new Money(0m, MoneyUnit.BTC), transaction.Outputs[2].Value);
+            Assert.Equal(opReturnData, new OpReturnDataReader(this.loggerFactory, this.network).GetStringFromOpReturn(transaction, out OpReturnDataType dummy));
+        }
+    }
+}


### PR DESCRIPTION
Resolves #108.

Some notes about the implementation:
- For purposes of deterministic ordering of input UTXO's they are ordered by transactions id and NOT by the position of the transaction within the block they occur in. This means that the ordering mainly by block age.
- Default output order has been retained.