### PR TITLE
Add sanity check to sync between store and wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,5 +245,6 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+/src/TestCase
 
 /src/Stratis.FederationGatewayD/Properties/PublishProfiles/FolderProfile.pubxml

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
@@ -12,6 +12,7 @@ using NBitcoin;
 using Stratis.Bitcoin;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Utilities;
 using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
 using Stratis.FederatedPeg.Features.FederationGateway.SourceChain;
@@ -54,7 +55,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         /// The caller must also ensure the transfers passed to this call all have a
         /// <see cref="CrossChainTransfer.Status"/> of <see cref="CrossChainTransferStatus.Partial"/>.
         /// </remarks>
-        Task RecordLatestMatureDeposits(IEnumerable<CrossChainTransfer> crossChainTransfers);
+        Task RecordLatestMatureDepositsAsync(IEnumerable<CrossChainTransfer> crossChainTransfers);
 
         /// <summary>
         /// Uses the information contained in our chain's blocks to update the store.
@@ -163,11 +164,14 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
         private readonly CancellationTokenSource cancellation;
 
+        private readonly IFederationWalletManager federationWalletManager;
+
         /// <summary>Provider of time functions.</summary>
         private readonly IDateTimeProvider dateTimeProvider;
 
         public CrossChainTransferStore(Network network, DataFolder dataFolder, ConcurrentChain chain, IFederationGatewaySettings settings, IDateTimeProvider dateTimeProvider,
-            ILoggerFactory loggerFactory, IOpReturnDataReader opReturnDataReader, IFullNode fullNode, IBlockRepository blockRepository)
+            ILoggerFactory loggerFactory, IOpReturnDataReader opReturnDataReader, IFullNode fullNode, IBlockRepository blockRepository,
+            IFederationWalletManager federationWalletManager)
         {
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(dataFolder, nameof(dataFolder));
@@ -178,11 +182,13 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             Guard.NotNull(opReturnDataReader, nameof(opReturnDataReader));
             Guard.NotNull(fullNode, nameof(fullNode));
             Guard.NotNull(blockRepository, nameof(blockRepository));
+            Guard.NotNull(federationWalletManager, nameof(federationWalletManager));
 
             this.network = network;
             this.chain = chain;
             this.dateTimeProvider = dateTimeProvider;
             this.blockRepository = blockRepository;
+            this.federationWalletManager = federationWalletManager;
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
 
@@ -240,10 +246,41 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         public void Start()
         {
             this.SynchronizeAsync().GetAwaiter().GetResult();
+            this.SanityCheckAsync().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Partial or fully signed transfers should have their source UTXO's recorded by the wallet.
+        /// Sets transfers to <see cref="CrossChainTransferStatus.Rejected"/> if their UTXO's are not
+        /// reserved within the wallet.
+        /// </summary>
+        public async Task SanityCheckAsync()
+        {
+            this.logger.LogTrace("()");
+
+            using (DBreeze.Transactions.Transaction dbreezeTransaction = this.DBreeze.GetTransaction())
+            {
+                dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
+
+                CrossChainTransfer[] partialTransfers = this.Get(dbreezeTransaction,
+                this.depositsIdsByStatus[CrossChainTransferStatus.Partial].Union(
+                    this.depositsIdsByStatus[CrossChainTransferStatus.FullySigned]).ToArray());
+
+                Wallet.FederationWallet wallet = this.federationWalletManager.GetWallet();
+
+                foreach (CrossChainTransfer partialTransfer in partialTransfers)
+                {
+                    if (!SanityCheck(partialTransfer.PartialTransaction, wallet))
+                    {
+                        this.SetTransferStatus(partialTransfer, CrossChainTransferStatus.Rejected);
+                        await this.PutTransferAsync(dbreezeTransaction, partialTransfer);
+                    }
+                }
+            }
         }
 
         /// <inheritdoc />
-        public async Task RecordLatestMatureDeposits(IEnumerable<CrossChainTransfer> crossChainTransfers)
+        public async Task RecordLatestMatureDepositsAsync(IEnumerable<CrossChainTransfer> crossChainTransfers)
         {
             Guard.NotNull(crossChainTransfers, nameof(crossChainTransfers));
             Guard.Assert(!crossChainTransfers.Any(t => !t.IsValid()));
@@ -698,6 +735,28 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             this.depositsIdsByStatus[transfer.Status].Remove(transfer.DepositTransactionId);
             transfer.SetStatus(status);
             this.depositsIdsByStatus[transfer.Status].Add(transfer.DepositTransactionId);
+        }
+
+        /// <summary>
+        /// Verifies that the transaction's inout UTXO's have been reserved by the wallet.
+        /// </summary>
+        /// <param name="transaction">The transaction to check.</param>
+        /// <param name="wallet">The wallet to check.</param>
+        /// <returns><c>True</c> if all's well and <c>false</c> otherwise.</returns>
+        private bool SanityCheck(Transaction transaction, Wallet.FederationWallet wallet)
+        {
+            // All the input UTXO's should be present in spending details of the multi-sig address.
+            foreach (TxIn input in transaction.Inputs)
+            {
+                Wallet.TransactionData transactionData = wallet.MultiSigAddress.Transactions
+                    .Where(t => t.SpendingDetails != null && t.SpendingDetails.TransactionId == transaction.GetHash()
+                        && t.Id == input.PrevOut.Hash && t.Index == input.PrevOut.N).FirstOrDefault();
+
+                if (transactionData == null)
+                    return false;
+            }
+
+            return true;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
@@ -743,7 +743,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         /// <param name="transaction">The transaction to check.</param>
         /// <param name="wallet">The wallet to check.</param>
         /// <returns><c>True</c> if all's well and <c>false</c> otherwise.</returns>
-        private bool SanityCheck(Transaction transaction, Wallet.FederationWallet wallet)
+        public static bool SanityCheck(Transaction transaction, Wallet.FederationWallet wallet)
         {
             // All the input UTXO's should be present in spending details of the multi-sig address.
             foreach (TxIn input in transaction.Inputs)

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
@@ -116,7 +116,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
             ILoggerFactory loggerFactory,
             Network network,
             ConcurrentChain chain,
-            NodeSettings settings, DataFolder dataFolder,
+            DataFolder dataFolder,
             IWalletFeePolicy walletFeePolicy,
             IAsyncLoopFactory asyncLoopFactory,
             INodeLifetime nodeLifetime,
@@ -127,7 +127,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
             Guard.NotNull(loggerFactory, nameof(loggerFactory));
             Guard.NotNull(network, nameof(network));
             Guard.NotNull(chain, nameof(chain));
-            Guard.NotNull(settings, nameof(settings));
             Guard.NotNull(dataFolder, nameof(dataFolder));
             Guard.NotNull(walletFeePolicy, nameof(walletFeePolicy));
             Guard.NotNull(asyncLoopFactory, nameof(asyncLoopFactory));

--- a/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -25,6 +25,7 @@ namespace Stratis.FederatedPeg.Tests
         private readonly IOpReturnDataReader opReturnDataReader;
         private readonly IBlockRepository blockRepository;
         private readonly IFullNode fullNode;
+        private readonly IFederationWalletManager federationWalletManager;
         private Dictionary<uint256, Block> blockDict;
 
         /// <summary>
@@ -41,6 +42,7 @@ namespace Stratis.FederatedPeg.Tests
             this.opReturnDataReader = new OpReturnDataReader(this.loggerFactory, this.network);
             this.blockRepository = Substitute.For<IBlockRepository>();
             this.fullNode = Substitute.For<IFullNode>();
+            this.federationWalletManager = Substitute.For<IFederationWalletManager>();
             this.blockDict = new Dictionary<uint256, Block>();
 
             this.blockRepository.GetBlocksAsync(Arg.Any<List<uint256>>()).ReturnsForAnyArgs((x) => {
@@ -74,7 +76,7 @@ namespace Stratis.FederatedPeg.Tests
             });
 
             using (var crossChainTransferStore = new CrossChainTransferStore(this.network, nodeSettings.DataFolder, chain, new FederationGatewaySettings(nodeSettings),
-                this.dateTimeProvider, this.loggerFactory, this.opReturnDataReader, this.fullNode, this.blockRepository))
+                this.dateTimeProvider, this.loggerFactory, this.opReturnDataReader, this.fullNode, this.blockRepository, this.federationWalletManager))
             {
                 crossChainTransferStore.Initialize();
 
@@ -102,7 +104,7 @@ namespace Stratis.FederatedPeg.Tests
             });
 
             using (var crossChainTransferStore = new CrossChainTransferStore(this.network, nodeSettings.DataFolder, chain, new FederationGatewaySettings(nodeSettings),
-                this.dateTimeProvider, this.loggerFactory, this.opReturnDataReader, this.fullNode, this.blockRepository))
+                this.dateTimeProvider, this.loggerFactory, this.opReturnDataReader, this.fullNode, this.blockRepository, this.federationWalletManager))
             {
                 crossChainTransferStore.Initialize();
 
@@ -116,7 +118,7 @@ namespace Stratis.FederatedPeg.Tests
             ConcurrentChain newChain = newTest.BuildChain(3);
 
             using (var crossChainTransferStore2 = new CrossChainTransferStore(newTest.network, nodeSettings.DataFolder, newChain, new FederationGatewaySettings(nodeSettings),
-                newTest.dateTimeProvider, newTest.loggerFactory, newTest.opReturnDataReader, newTest.fullNode, newTest.blockRepository))
+                newTest.dateTimeProvider, newTest.loggerFactory, newTest.opReturnDataReader, newTest.fullNode, newTest.blockRepository, this.federationWalletManager))
             {
                 crossChainTransferStore2.Initialize();
 

--- a/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -67,10 +67,13 @@ namespace Stratis.FederatedPeg.Tests
             ConcurrentChain chain = BuildChain(5);
 
             string dataDir = CreateTestDir(this);
+
+            Guard.NotNull(dataDir, nameof(dataDir));
+
+            var dataFolder = new DataFolder(dataDir);
             var nodeSettings = new NodeSettings(this.network, NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION,
                 args: new[] {
                     "-mainchain",
-                    $"-datadir={dataDir}",
                     "-redeemscript=2 026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c 02a97b7d0fad7ea10f456311dcd496ae9293952d4c5f2ebdfc32624195fde14687 02e9d3cd0c2fa501957149ff9d21150f3901e6ece0e3fe3007f2372720c84e3ee1 03c99f997ed71c7f92cf532175cea933f2f11bf08f1521d25eb3cc9b8729af8bf4 034b191e3b3107b71d1373e840c5bf23098b55a355ca959b968993f5dec699fc38 5 OP_CHECKMULTISIG",
                     "-publickey=026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c"
             });
@@ -95,15 +98,15 @@ namespace Stratis.FederatedPeg.Tests
             ConcurrentChain chain = BuildChain(5);
 
             string dataDir = CreateTestDir(this);
+            var dataFolder = new DataFolder(dataDir);
             var nodeSettings = new NodeSettings(this.network, NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION,
                 args: new[] {
                     "-mainchain",
-                    $"-datadir={dataDir}",
                     "-redeemscript=2 026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c 02a97b7d0fad7ea10f456311dcd496ae9293952d4c5f2ebdfc32624195fde14687 02e9d3cd0c2fa501957149ff9d21150f3901e6ece0e3fe3007f2372720c84e3ee1 03c99f997ed71c7f92cf532175cea933f2f11bf08f1521d25eb3cc9b8729af8bf4 034b191e3b3107b71d1373e840c5bf23098b55a355ca959b968993f5dec699fc38 5 OP_CHECKMULTISIG",
                     "-publickey=026ebcbf6bfe7ce1d957adbef8ab2b66c788656f35896a170257d6838bda70b95c"
             });
 
-            using (var crossChainTransferStore = new CrossChainTransferStore(this.network, nodeSettings.DataFolder, chain, new FederationGatewaySettings(nodeSettings),
+            using (var crossChainTransferStore = new CrossChainTransferStore(this.network, dataFolder, chain, new FederationGatewaySettings(nodeSettings),
                 this.dateTimeProvider, this.loggerFactory, this.opReturnDataReader, this.fullNode, this.blockRepository, this.federationWalletManager))
             {
                 crossChainTransferStore.Initialize();
@@ -117,7 +120,7 @@ namespace Stratis.FederatedPeg.Tests
             var newTest = new CrossChainTransferStoreTests();
             ConcurrentChain newChain = newTest.BuildChain(3);
 
-            using (var crossChainTransferStore2 = new CrossChainTransferStore(newTest.network, nodeSettings.DataFolder, newChain, new FederationGatewaySettings(nodeSettings),
+            using (var crossChainTransferStore2 = new CrossChainTransferStore(newTest.network, dataFolder, newChain, new FederationGatewaySettings(nodeSettings),
                 newTest.dateTimeProvider, newTest.loggerFactory, newTest.opReturnDataReader, newTest.fullNode, newTest.blockRepository, this.federationWalletManager))
             {
                 crossChainTransferStore2.Initialize();

--- a/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -66,7 +66,7 @@ namespace Stratis.FederatedPeg.Tests
         {
             ConcurrentChain chain = BuildChain(5);
 
-            string dataDir = GetTestDirectoryPath(this);
+            string dataDir = CreateTestDir(this);
             var nodeSettings = new NodeSettings(this.network, NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION,
                 args: new[] {
                     "-mainchain",
@@ -94,7 +94,7 @@ namespace Stratis.FederatedPeg.Tests
         {
             ConcurrentChain chain = BuildChain(5);
 
-            string dataDir = GetTestDirectoryPath(this);
+            string dataDir = CreateTestDir(this);
             var nodeSettings = new NodeSettings(this.network, NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION,
                 args: new[] {
                     "-mainchain",
@@ -189,6 +189,18 @@ namespace Stratis.FederatedPeg.Tests
         }
 
         /// <summary>
+        /// Creates a directory for a test, based on the name of the class containing the test and the name of the test.
+        /// </summary>
+        /// <param name="caller">The calling object, from which we derive the namespace in which the test is contained.</param>
+        /// <param name="callingMethod">The name of the test being executed. A directory with the same name will be created.</param>
+        /// <returns>The path of the directory that was created.</returns>
+        public static string CreateTestDir(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
+        {
+            string directoryPath = GetTestDirectoryPath(caller, callingMethod);
+            return AssureEmptyDir(directoryPath);
+        }
+
+        /// <summary>
         /// Gets the path of the directory that <see cref="CreateTestDir(object, string)"/> or <see cref="CreateDataFolder(object, string)"/> would create.
         /// </summary>
         /// <remarks>The path of the directory is of the form TestCase/{testClass}/{testName}.</remarks>
@@ -197,7 +209,25 @@ namespace Stratis.FederatedPeg.Tests
         /// <returns>The path of the directory.</returns>
         public static string GetTestDirectoryPath(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
         {
-            return Path.Combine(Path.GetTempPath() ?? ".", caller.GetType().Name, callingMethod);
+            return GetTestDirectoryPath(Path.Combine(caller.GetType().Name, callingMethod));
+        }
+
+        /// <summary>
+        /// Gets the path of the directory that <see cref="CreateTestDir(object, string)"/> would create.
+        /// </summary>
+        /// <remarks>The path of the directory is of the form TestCase/{testClass}/{testName}.</remarks>
+        /// <param name="testDirectory">The directory in which the test files are contained.</param>
+        /// <returns>The path of the directory.</returns>
+        public static string GetTestDirectoryPath(string testDirectory)
+        {
+            return Path.Combine("..", "..", "..", "..", "TestCase", testDirectory);
+        }
+
+        public static string AssureEmptyDir(string dir)
+        {
+            string uniqueDirName = $"{dir}-{DateTime.UtcNow:ddMMyyyyTHH.mm.ss.fff}";
+            Directory.CreateDirectory(uniqueDirName);
+            return uniqueDirName;
         }
     }
 }

--- a/src/Stratis.FederatedPeg.Tests/TransactionBuilderTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/TransactionBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -38,7 +39,7 @@ namespace Stratis.FederatedPeg.Tests
         public TransactionBuilderTests()
         {
             this.network = ApexNetwork.RegTest;
-            string dataDir = GetTestDirectoryPath(this);
+            string dataDir = CreateTestDir(this);
             if (Directory.Exists(dataDir))
                 Directory.Delete(dataDir, true);
             this.nodeSettings = new NodeSettings(this.network, NBitcoin.Protocol.ProtocolVersion.ALT_PROTOCOL_VERSION,
@@ -246,15 +247,45 @@ namespace Stratis.FederatedPeg.Tests
         }
 
         /// <summary>
+        /// Creates a directory for a test, based on the name of the class containing the test and the name of the test.
+        /// </summary>
+        /// <param name="caller">The calling object, from which we derive the namespace in which the test is contained.</param>
+        /// <param name="callingMethod">The name of the test being executed. A directory with the same name will be created.</param>
+        /// <returns>The path of the directory that was created.</returns>
+        public static string CreateTestDir(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
+        {
+            string directoryPath = GetTestDirectoryPath(caller, callingMethod);
+            return AssureEmptyDir(directoryPath);
+        }
+
+        /// <summary>
         /// Gets the path of the directory that <see cref="CreateTestDir(object, string)"/> or <see cref="CreateDataFolder(object, string)"/> would create.
         /// </summary>
         /// <remarks>The path of the directory is of the form TestCase/{testClass}/{testName}.</remarks>
         /// <param name="caller">The calling object, from which we derive the namespace in which the test is contained.</param>
         /// <param name="callingMethod">The name of the test being executed. A directory with the same name will be created.</param>
         /// <returns>The path of the directory.</returns>
-        private static string GetTestDirectoryPath(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
+        public static string GetTestDirectoryPath(object caller, [System.Runtime.CompilerServices.CallerMemberName] string callingMethod = "")
         {
-            return Path.Combine(Path.GetTempPath() ?? ".", caller.GetType().Name, callingMethod);
+            return GetTestDirectoryPath(Path.Combine(caller.GetType().Name, callingMethod));
+        }
+
+        /// <summary>
+        /// Gets the path of the directory that <see cref="CreateTestDir(object, string)"/> would create.
+        /// </summary>
+        /// <remarks>The path of the directory is of the form TestCase/{testClass}/{testName}.</remarks>
+        /// <param name="testDirectory">The directory in which the test files are contained.</param>
+        /// <returns>The path of the directory.</returns>
+        public static string GetTestDirectoryPath(string testDirectory)
+        {
+            return Path.Combine("..", "..", "..", "..", "TestCase", testDirectory);
+        }
+
+        public static string AssureEmptyDir(string dir)
+        {
+            string uniqueDirName = $"{dir}-{DateTime.UtcNow:ddMMyyyyTHH.mm.ss.fff}";
+            Directory.CreateDirectory(uniqueDirName);
+            return uniqueDirName;
         }
     }
 }

--- a/src/Stratis.FederatedPeg.Tests/TransactionBuilderTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/TransactionBuilderTests.cs
@@ -12,6 +12,7 @@ using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Utilities;
 using Stratis.FederatedPeg.Features.FederationGateway;
 using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
+using Stratis.FederatedPeg.Features.FederationGateway.TargetChain;
 using Stratis.FederatedPeg.Features.FederationGateway.Wallet;
 using Stratis.Sidechains.Networks;
 using Xunit;
@@ -159,7 +160,7 @@ namespace Stratis.FederatedPeg.Tests
             this.federationWalletManager.ProcessTransaction(transaction1);
 
             // All the input UTXO's should be present in spending details of the multi-sig address.
-            Assert.True(this.SanityCheck(transaction1));
+            Assert.True(CrossChainTransferStore.SanityCheck(transaction1, this.wallet));
 
             // Confirm this can be done twice without ill effect.
             // (We may have to re-reserve UTXO's associated with partial transactions after a node restart or re-org.)
@@ -216,29 +217,8 @@ namespace Stratis.FederatedPeg.Tests
             this.federationWalletManager.ProcessTransaction(transaction2);
 
             // All the input UTXO's should be present in spending details of the multi-sig address.
-            Assert.True(this.SanityCheck(transaction2));
+            Assert.True(CrossChainTransferStore.SanityCheck(transaction2, this.wallet));
 
-        }
-
-        /// <summary>
-        /// Verifies that the transaction's inout UTXO's have been reserved by the wallet.
-        /// </summary>
-        /// <param name="transaction">The transaction to check.</param>
-        /// <returns><c>True</c> if all's well and <c>false</c> otherwise.</returns>
-        private bool SanityCheck(Transaction transaction)
-        {
-            // All the input UTXO's should be present in spending details of the multi-sig address.
-            foreach (TxIn input in transaction.Inputs)
-            {
-                TransactionData transactionData = this.wallet.MultiSigAddress.Transactions
-                    .Where(t => t.SpendingDetails != null && t.SpendingDetails.TransactionId == transaction.GetHash()
-                        && t.Id == input.PrevOut.Hash && t.Index == input.PrevOut.N).FirstOrDefault();
-
-                if (transactionData == null)
-                    return false;
-            }
-
-            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Relates to #137 

- On restart we have to check that our transaction's UTXO's are still valid.
- Once ProcessTransaction has been called we want to check that UTXO's are not re-used.