### PR TITLE
new nuget source

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
+    <add key="stratis-dev" value="https://pkgs.dev.azure.com/StratisProject/_packaging/nuget_packages_feed/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
powershell-core is not used any more, so it gets replaced