### PR TITLE
Fix deposit extractor

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/DepositExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/DepositExtractor.cs
@@ -27,7 +27,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
             IFullNode fullNode)
         {
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            this.depositScript = federationGatewaySettings.MultiSigRedeemScript;
+            // Note: MultiSigRedeemScript.PaymentScript equals MultiSigAddress.ScriptPubKey
+            this.depositScript =
+                federationGatewaySettings?.MultiSigRedeemScript?.PaymentScript ??
+                federationGatewaySettings?.MultiSigAddress?.ScriptPubKey;
             this.opReturnDataReader = opReturnDataReader;
             this.MinimumDepositConfirmations = federationGatewaySettings.MinimumDepositConfirmations;
             this.chain = fullNode.NodeService<ConcurrentChain>();

--- a/src/Stratis.FederatedPeg.Tests/DepositExtractorTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/DepositExtractorTests.cs
@@ -46,14 +46,14 @@ namespace Stratis.FederatedPeg.Tests
 
             this.addressHelper = new MultisigAddressHelper(this.network);
 
-            this.settings.MultiSigRedeemScript.Returns(this.addressHelper.SourceChainMultisigAddress.ScriptPubKey);
+            this.settings.MultiSigRedeemScript.Returns(this.addressHelper.PayToMultiSig);
             this.opReturnDataReader.TryGetTargetAddress(null).ReturnsForAnyArgs((string)null);
 
             this.transactionBuilder = new TestTransactionBuilder();
 
             this.depositExtractor = new DepositExtractor(
-                this.loggerFactory, 
-                this.settings, 
+                this.loggerFactory,
+                this.settings,
                 this.opReturnDataReader,
                 this.fullNode);
         }


### PR DESCRIPTION
Changes the initialisation of `this.depositScript` from:
```
this.depositScript = federationGatewaySettings.MultiSigRedeemScript;
```
to
```
            // Note: MultiSigRedeemScript.PaymentScript equals MultiSigAddress.ScriptPubKey
            this.depositScript =
                federationGatewaySettings?.MultiSigRedeemScript?.PaymentScript ??
                federationGatewaySettings?.MultiSigAddress?.ScriptPubKey;
```
to fix the issue where deposits are not being extracted.