### PR TITLE
Fix the block definition for SmartContracts

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederatedPegBlockDefinition.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederatedPegBlockDefinition.cs
@@ -47,7 +47,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
                                    ? this.payToMultisigScript 
                                    : this.payToMemberScript;
 
-            base.OnBuild(chainTip, rewardScript);
+            base.Build(chainTip, rewardScript);
 
             return this.BlockTemplate;
         }

--- a/src/Stratis.FederatedPeg.IntegrationTests/Utils/PowerShellScriptGeneratorAsTests.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/Utils/PowerShellScriptGeneratorAsTests.cs
@@ -78,7 +78,7 @@ namespace Stratis.FederatedPeg.Tests.Utils
             this.federationMemberIndexes.ForEach(i =>
             {
                 var privateKey = this.mnemonics[i].DeriveExtKey().PrivateKey;
-                var targetFile = $"$root_datadir\\gateway{i + 1}\\poa\\FederatedPegTest\\federationKey.dat";
+                var targetFile = $"$root_datadir\\gateway{i + 1}\\fedpeg\\FederatedPegRegTest\\federationKey.dat";
 
                 var keyAsString = System.BitConverter.ToString(privateKey.ToBytes());
                 this.newLine($"$mining_key_hex_{i + 1} = \"{keyAsString}\"");
@@ -93,13 +93,13 @@ namespace Stratis.FederatedPeg.Tests.Utils
         {
             this.newLine("# MainchainUser");
             this.newLine("cd $path_to_stratisd");
-            this.newLine($"start-process cmd -ArgumentList \"/k color {this.consoleColors[5]} && dotnet run --no-build -testnet -port=36178 -apiport=38221 -agentprefix=mainuser -datadir=$root_datadir\\MainchainUser -addnode=13.70.81.5 -addnode=52.151.76.252 -whitelist=52.151.76.252 -gateway=1\"");
+            this.newLine($"start-process cmd -ArgumentList \"/k color {this.consoleColors[5]} && dotnet run -testnet -port=36178 -apiport=38221 -agentprefix=mainuser -datadir=$root_datadir\\MainchainUser -addnode=13.70.81.5 -addnode=52.151.76.252 -whitelist=52.151.76.252 -gateway=1\"");
             this.newLine("timeout $interval_time");
             this.newLine(Environment.NewLine);
 
             this.newLine("# SidechainUser");
             this.newLine("cd $path_to_sidechaind");
-            this.newLine($"start-process cmd -ArgumentList \"/k color {this.consoleColors[4]} && dotnet run --no-build -testnet -port=26179 -apiport=38225 -agentprefix=sideuser -datadir=$root_datadir\\SidechainUser agentprefix=sc_user -addnode=127.0.0.1:36{GetPortNumberSuffix(this.chains[1], 0)} -addnode=127.0.0.1:36{GetPortNumberSuffix(this.chains[1], 1)} -addnode=127.0.0.1:36{GetPortNumberSuffix(this.chains[1], 2)}\"");
+            this.newLine($"start-process cmd -ArgumentList \"/k color {this.consoleColors[4]} && dotnet run -regtest -port=26179 -apiport=38225 -agentprefix=sideuser -datadir=$root_datadir\\SidechainUser agentprefix=sc_user -addnode=127.0.0.1:36{GetPortNumberSuffix(this.chains[1], 0)} -addnode=127.0.0.1:36{GetPortNumberSuffix(this.chains[1], 1)} -addnode=127.0.0.1:36{GetPortNumberSuffix(this.chains[1], 2)}\"");
             this.newLine("timeout $interval_time");
             this.newLine(Environment.NewLine);
         }
@@ -110,10 +110,10 @@ namespace Stratis.FederatedPeg.Tests.Utils
             federationMemberIndexes.ForEach(i => {
                 this.newLine($"# Federation member {i} main and side");
                 this.newLine(
-                    $"start-process cmd -ArgumentList \"/k color {this.consoleColors[i + 1]} && dotnet run --no-build -mainchain -testnet -agentprefix=fed{i + 1}main -datadir=$root_datadir\\gateway{i + 1} -port=36{GetPortNumberSuffix(this.chains[0], i)} -apiport=38{GetPortNumberSuffix(this.chains[0], i)} -counterchainapiport=38{GetPortNumberSuffix(this.chains[1], i)} -federationips=$mainchain_federationips -redeemscript=\"\"$redeemscript\"\" -publickey=$gateway{i + 1}_public_key -mincoinmaturity=1 -mindepositconfirmations=1 -addnode=13.70.81.5 -addnode=52.151.76.252 -whitelist=52.151.76.252 -gateway=1\"");
+                    $"start-process cmd -ArgumentList \"/k color {this.consoleColors[i + 1]} && dotnet run --no-build -mainchain -testnet -agentprefix=fed{i + 1}main -datadir=$root_datadir\\gateway{i + 1} -port=36{GetPortNumberSuffix(this.chains[0], i)} -apiport=38{GetPortNumberSuffix(this.chains[0], i)} -counterchainapiport=38{GetPortNumberSuffix(this.chains[1], i)} -federationips=$mainchain_federationips -redeemscript=\"\"$redeemscript\"\" -publickey=$gateway{i + 1}_public_key -mincoinmaturity=1 -mindepositconfirmations=1\"");
                 this.newLine("timeout $long_interval_time");
                 this.newLine(
-                    $"start-process cmd -ArgumentList \"/k color {this.consoleColors[i + 1]} && dotnet run --no-build -sidechain -testnet -agentprefix=fed{i + 1}side -datadir=$root_datadir\\gateway{i + 1} -port=36{GetPortNumberSuffix(this.chains[1], i)} -apiport=38{GetPortNumberSuffix(this.chains[1], i)} -counterchainapiport=38{GetPortNumberSuffix(this.chains[0], i)} -federationips=$sidechain_federationips -redeemscript=\"\"$redeemscript\"\" -publickey=$gateway{i + 1}_public_key -mincoinmaturity=1 -mindepositconfirmations=1 -txindex=1\"");
+                    $"start-process cmd -ArgumentList \"/k color {this.consoleColors[i + 1]} && dotnet run --no-build -sidechain -regtest -agentprefix=fed{i + 1}side -datadir=$root_datadir\\gateway{i + 1} -port=36{GetPortNumberSuffix(this.chains[1], i)} -apiport=38{GetPortNumberSuffix(this.chains[1], i)} -counterchainapiport=38{GetPortNumberSuffix(this.chains[0], i)} -federationips=$sidechain_federationips -redeemscript=\"\"$redeemscript\"\" -publickey=$gateway{i + 1}_public_key -mincoinmaturity=1 -mindepositconfirmations=1 -txindex=1\"");
                 this.newLine("timeout $long_interval_time");
                 this.newLine(Environment.NewLine);
             });
@@ -128,9 +128,9 @@ namespace Stratis.FederatedPeg.Tests.Utils
             this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway2\stratis\StratisTest");
             this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway3\stratis\StratisTest");
             this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\MainchainUser\stratis\StratisTest");
-            this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway1\poa\FederatedPegTest");
-            this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway2\poa\FederatedPegTest");
-            this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway3\poa\FederatedPegTest");
+            this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway1\fedpeg\FederatedPegRegTest");
+            this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway2\fedpeg\FederatedPegRegTest");
+            this.newLine(@"New-Item -ItemType directory -Force -Path $root_datadir\gateway3\fedpeg\FederatedPegRegTest");
             this.newLine(Environment.NewLine);
 
             // Copy the blockchain data from a current, ideally up-to-date, Stratis Testnet folder.

--- a/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/FederatedPegRegTest.cs
@@ -15,6 +15,14 @@ namespace Stratis.Sidechains.Networks
     public class FederatedPegRegTest : PoANetwork
     {
         public IList<Mnemonic> FederationMnemonics { get; }
+
+        /// <summary> The name of the root folder containing the different federated peg blockchains.</summary>
+        private const string NetworkRootFolderName = "fedpeg";
+
+        /// <summary> The default name used for the federated peg configuration file. </summary>
+        private const string NetworkDefaultConfigFilename = "fedpeg.conf";
+
+        // public IList<Mnemonic> FederationMnemonics { get; }
         public IList<Key> FederationKeys { get; private set; }
 
         internal FederatedPegRegTest()
@@ -22,6 +30,17 @@ namespace Stratis.Sidechains.Networks
             this.Name = FederatedPegNetwork.RegTestNetworkName;
             this.CoinTicker = FederatedPegNetwork.TestCoinSymbol;
             this.Magic = 0x522357C;
+            this.DefaultPort = 26179;
+            this.DefaultMaxOutboundConnections = 16;
+            this.DefaultMaxInboundConnections = 109;
+            this.RPCPort = 26175;
+            this.MaxTipAge = 2 * 60 * 60;
+            this.MinTxFee = 10000;
+            this.FallbackFee = 10000;
+            this.MinRelayTxFee = 10000;
+            this.RootFolderName = NetworkRootFolderName;
+            this.DefaultConfigFilename = NetworkDefaultConfigFilename;
+            this.MaxTimeOffsetSeconds = 25 * 60;
 
             var consensusFactory = new SmartContractPoAConsensusFactory();
 
@@ -101,8 +120,8 @@ namespace Stratis.Sidechains.Networks
 
             // Same as current smart contracts test networks to keep tests working
             this.Base58Prefixes = new byte[12][];
-            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (38) }; //G
-            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (97) }; //g
+            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { 55 }; // P
+            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { 117 }; // p
             this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
             this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
             this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };


### PR DESCRIPTION
The important change is in FederatedPegBlockDefinition.cs.
We were calling the BlockDefiniton's Onbuild method directly rather than the smartContract's one.

Changed RegTest so that it can be used with StratisTest and the local powershell script.