### PR TITLE
Add default collection if federationips param is not set

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -167,12 +167,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             this.maturedBlockRequester.Start();
 
             // Connect the node to the other federation members.
-            if (this.federationGatewaySettings.FederationNodeIpEndPoints != null)
+            foreach (var federationMemberIp in this.federationGatewaySettings.FederationNodeIpEndPoints)
             {
-                foreach (var federationMemberIp in this.federationGatewaySettings.FederationNodeIpEndPoints)
-                {
-                    this.connectionManager.AddNodeAddress(federationMemberIp);
-                }
+                this.connectionManager.AddNodeAddress(federationMemberIp);
             }
 
             var networkPeerConnectionParameters = this.connectionManager.Parameters;

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewaySettings.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewaySettings.cs
@@ -63,7 +63,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
 
             this.CounterChainApiPort = configReader.GetOrDefault(CounterChainApiPortParam, 0);
             this.FederationNodeIpEndPoints = configReader.GetOrDefault<string>(FederationIpsParam, null)?.Split(',')
-                .Select(a => a.ToIPEndPoint(nodeSettings.Network.DefaultPort));
+                .Select(a => a.ToIPEndPoint(nodeSettings.Network.DefaultPort)) ?? new List<IPEndPoint>();
 
             //todo : remove that for prod code
             this.MinimumDepositConfirmations = (uint)configReader.GetOrDefault<int>(MinimumDepositConfirmationsParam, (int)nodeSettings.Network.Consensus.MaxReorgLength + 1);


### PR DESCRIPTION
FederationNodeIpEndPoints will be null if no federation node IPs are passed in, causing an `PartialTransactionsBehavior.AttachCore` to throw an exception.