### PR TITLE
Running non-stop

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IEventPersister.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IEventPersister.cs
@@ -11,11 +11,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
     public interface IEventPersister
     {
         /// <summary>
-        /// When new matured block arrive, this will trigger a call to the store to persist the given deposits.
-        /// </summary>
-        Task PersistNewMaturedBlockDepositsAsync(IMaturedBlockDeposits[] maturedBlockDeposits);
-
-        /// <summary>
         /// When a new block is produced on the source chain, this will persist the new tip in the store.
         /// </summary>
         Task PersistNewSourceChainTip(IBlockTip newTip);

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
@@ -114,7 +114,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// <param name="depositId">Filters by this deposit id if not <c>null</c>.</param>
         /// <param name="transactionId">Filters by this transaction id if not <c>null</c>.</param>
         /// <returns>The transaction data containing the withdrawal transaction.</returns>
-        List<(Transaction, TransactionData)> FindWithdrawalTransactions(uint256 depositId = null, uint256 transactionId = null);
+        List<(Transaction, TransactionData, IWithdrawal)> FindWithdrawalTransactions(uint256 depositId = null);
 
         /// <summary>
         /// Removes the transient transactions associated with the corresponding deposit ids.

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/EventsPersister.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/EventsPersister.cs
@@ -27,12 +27,12 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             this.maturedBlocksRequester = maturedBlocksRequester;
             this.lockObj = new object();
 
-            this.maturedBlockDepositSubscription = maturedBlockReceiver.MaturedBlockDepositStream.Subscribe(async m => PersistNewMaturedBlockDepositsAsync(m) );
+            this.maturedBlockDepositSubscription = maturedBlockReceiver.MaturedBlockDepositStream.Subscribe(async m => PersistNewMaturedBlockDeposits(m) );
             this.logger.LogDebug("Subscribed to {0}", nameof(maturedBlockReceiver), nameof(maturedBlockReceiver.MaturedBlockDepositStream));
         }
 
         /// <inheritdoc />
-        public void PersistNewMaturedBlockDepositsAsync(IMaturedBlockDeposits[] maturedBlockDeposits)
+        public void PersistNewMaturedBlockDeposits(IMaturedBlockDeposits[] maturedBlockDeposits)
         {
             lock (this.lockObj)
             {

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/EventsPersister.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/EventsPersister.cs
@@ -15,6 +15,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
         private readonly IMaturedBlocksRequester maturedBlocksRequester;
 
+        private readonly object lockObj;
+
         public EventsPersister(ILoggerFactory loggerFactory,
                                ICrossChainTransferStore store,
                                IMaturedBlockReceiver maturedBlockReceiver,
@@ -23,20 +25,24 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.store = store;
             this.maturedBlocksRequester = maturedBlocksRequester;
+            this.lockObj = new object();
 
-            this.maturedBlockDepositSubscription = maturedBlockReceiver.MaturedBlockDepositStream.Subscribe(async m => await PersistNewMaturedBlockDepositsAsync(m).ConfigureAwait(false));
+            this.maturedBlockDepositSubscription = maturedBlockReceiver.MaturedBlockDepositStream.Subscribe(async m => PersistNewMaturedBlockDepositsAsync(m) );
             this.logger.LogDebug("Subscribed to {0}", nameof(maturedBlockReceiver), nameof(maturedBlockReceiver.MaturedBlockDepositStream));
         }
 
         /// <inheritdoc />
-        public async Task PersistNewMaturedBlockDepositsAsync(IMaturedBlockDeposits[] maturedBlockDeposits)
+        public void PersistNewMaturedBlockDepositsAsync(IMaturedBlockDeposits[] maturedBlockDeposits)
         {
-            this.logger.LogDebug("New {0} received.", nameof(IMaturedBlockDeposits));
-
-            if (await this.store.RecordLatestMatureDepositsAsync(maturedBlockDeposits).ConfigureAwait(false))
+            lock (this.lockObj)
             {
-                // There may be more blocks. Get them.
-                await this.maturedBlocksRequester.GetMoreBlocksAsync().ConfigureAwait(false);
+                this.logger.LogDebug("New {0} received.", nameof(IMaturedBlockDeposits));
+
+                if (this.store.RecordLatestMatureDepositsAsync(maturedBlockDeposits).ConfigureAwait(false).GetAwaiter().GetResult())
+                {
+                    // There may be more blocks. Get them.
+                    this.maturedBlocksRequester.GetMoreBlocksAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                }
             }
         }
 


### PR DESCRIPTION
This PR gets the cross-chain transfers to run non-stop.

After these changes I was able to process the following 5 deposits found on Stratis Testnet without stopping (list of deposit ids): EB28..., 5387..., FAA0..., 72B2... and 171F... Corresponding block heights: 667197, 667311, 667361, 668602 and 668620. Deposit amounts: 1.0, 1.1, 3.14, 23.0 and 15.0.

Goals of this PR:
- Remove unnecessary transactionId parameter  from FindWithdrawalTransactions.
- Moved code outside of the lock to inside the lock and also added logic to check if a withdrawal  
  transaction is already present in the wallet (keyed by depositId).
- Update ValidateCrossChainTransfer to identify wallet transactions by deposit id vs transaction id.
  Adopts the wallet transaction if present and sets  an appropriate status.
- Remove transactions that should no longer be visible in the wallet if the chain A tip is changed.
- Added a lock to PersistNewMaturedBlockDepositsAsync  to avoid race conditions.
- Updated the FederationWalletManager's ProcessTransaction  to identify existing transactions by deposit Id.
