### PR TITLE
fix methods in opreturn reader

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IOpReturnDataReader.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IOpReturnDataReader.cs
@@ -15,14 +15,16 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// Tries to find a single OP_RETURN output that can be interpreted as an address.
         /// </summary>
         /// <param name="transaction">The transaction we are examining.</param>
-        /// <returns>The address as a string, or null if nothing is found, or if multiple addresses are found.</returns>
-        string TryGetTargetAddress(Transaction transaction);
+        /// <param name="address">The address as a string, or null if nothing is found, or if multiple addresses are found.</param>
+        /// <returns><c>true</c> if address was extracted; <c>false</c> otherwise.</returns>
+        bool TryGetTargetAddress(Transaction transaction, out string address);
 
         /// <summary>
         /// Tries to find a single OP_RETURN output that can be interpreted as a transaction id.
         /// </summary>
         /// <param name="transaction">The transaction we are examining.</param>
-        /// <returns>The transaction id as a string, or null if nothing is found, or if multiple ids are found.</returns>
-        string TryGetTransactionId(Transaction transaction);
+        /// <param name="txId">The transaction id as a string, or null if nothing is found, or if multiple ids are found.</param>
+        /// <returns><c>true</c> if transaction id was extracted; <c>false</c> otherwise.</returns>
+        bool TryGetTransactionId(Transaction transaction, out string txId);
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/OpReturnDataReader.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/OpReturnDataReader.cs
@@ -21,8 +21,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             this.network = network;
         }
 
-        ///<inheritdoc />
-        public string TryGetTargetAddress(Transaction transaction)
+        /// <inheritdoc />
+        public bool TryGetTargetAddress(Transaction transaction, out string address)
         {
             List<string> opReturnAddresses = SelectBytesContentFromOpReturn(transaction)
                 .Select(this.TryConvertValidOpReturnDataToAddress)
@@ -32,11 +32,18 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             this.logger.LogDebug("Address(es) found in OP_RETURN(s) of transaction {0}: [{1}]",
                 transaction.GetHash(), string.Join(",", opReturnAddresses));
 
-            return opReturnAddresses.Count != 1 ? null : opReturnAddresses[0];
+            if (opReturnAddresses.Count != 1)
+            {
+                address = null;
+                return false;
+            }
+
+            address = opReturnAddresses[0];
+            return true;
         }
 
         /// <inheritdoc />
-        public string TryGetTransactionId(Transaction transaction)
+        public bool TryGetTransactionId(Transaction transaction, out string txId)
         {
             List<string> transactionId = SelectBytesContentFromOpReturn(transaction)
                 .Select(this.TryConvertValidOpReturnDataToHash)
@@ -46,7 +53,14 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             this.logger.LogDebug("Transaction Id(s) found in OP_RETURN(s) of transaction {0}: [{1}]",
                 transaction.GetHash(), string.Join(",", transactionId));
 
-            return transactionId.Count != 1 ? null : transactionId[0];
+            if (transactionId.Count != 1)
+            {
+                txId = null;
+                return false;
+            }
+
+            txId = transactionId[0];
+            return true;
         }
 
         private static IEnumerable<byte[]> SelectBytesContentFromOpReturn(Transaction transaction)

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/DepositExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/DepositExtractor.cs
@@ -64,8 +64,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
             if (!depositsToMultisig.Any())
                 return null;
 
-            string targetAddress = this.opReturnDataReader.TryGetTargetAddress(transaction);
-            if (string.IsNullOrWhiteSpace(targetAddress))
+            if (!this.opReturnDataReader.TryGetTargetAddress(transaction, out string targetAddress))
                 return null;
 
             this.logger.LogInformation("Processing received transaction with address: {0}. Transaction hash: {1}.",

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalExtractor.cs
@@ -49,8 +49,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             if (transaction.Outputs.Count(this.IsTargetAddressCandidate) != 1) return null;
             if (!IsOnlyFromMultisig(transaction)) return null;
 
-            string depositId = this.opReturnDataReader.TryGetTransactionId(transaction);
-            if (string.IsNullOrWhiteSpace(depositId)) return null;
+            if (!this.opReturnDataReader.TryGetTransactionId(transaction, out string depositId))
+                return null;
 
             this.logger.LogTrace(
                 "Processing received transaction with source deposit id: {0}. Transaction hash: {1}.",

--- a/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -148,7 +148,8 @@ namespace Stratis.FederatedPeg.Tests
 
                 // Transaction[0] output value - op_return.
                 Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[0].Outputs[2].Value);
-                Assert.Equal(deposit1.Id.ToString(), new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[0]));
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[0], out string actualDepositId);
+                Assert.Equal(deposit1.Id.ToString(), actualDepositId);
 
                 // Transactions[1] inputs.
                 Assert.Single(transactions[1].Inputs);
@@ -168,7 +169,8 @@ namespace Stratis.FederatedPeg.Tests
 
                 // Transaction[1] output value - op_return.
                 Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[1].Outputs[2].Value);
-                Assert.Equal(deposit2.Id.ToString(), new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[1]));
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[1], out string actualDepositId2);
+                Assert.Equal(deposit2.Id.ToString(), actualDepositId2);
 
                 ICrossChainTransfer[] transfers = crossChainTransferStore.GetAsync(new uint256[] { 0, 1 }).GetAwaiter().GetResult().ToArray();
 
@@ -245,7 +247,8 @@ namespace Stratis.FederatedPeg.Tests
 
                 // Transaction[0] output value - op_return.
                 Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[0].Outputs[2].Value);
-                Assert.Equal(deposit1.Id.ToString(), new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[0]));
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[0], out string actualDepositId);
+                Assert.Equal(deposit1.Id.ToString(), actualDepositId);
 
                 Assert.Null(transactions[1]);
 
@@ -279,7 +282,8 @@ namespace Stratis.FederatedPeg.Tests
 
                 // Transaction[1] output value - op_return.
                 Assert.Equal(new Money(0m, MoneyUnit.BTC), transactions[1].Outputs[2].Value);
-                Assert.Equal(deposit2.Id.ToString(), new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[1]));
+                new OpReturnDataReader(this.loggerFactory, this.network).TryGetTransactionId(transactions[1], out string actualDepositId2);
+                Assert.Equal(deposit2.Id.ToString(), actualDepositId2);
 
                 Assert.Equal(2, transfers.Length);
                 Assert.Equal(CrossChainTransferStatus.Partial, transfers[1].Status);

--- a/src/Stratis.FederatedPeg.Tests/OpReturnDataReaderTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/OpReturnDataReaderTests.cs
@@ -40,7 +40,7 @@ namespace Stratis.FederatedPeg.Tests
             byte[] opReturnBytes = Encoding.UTF8.GetBytes(opReturnAddress.ToString());
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
 
-            string addressFromOpReturn = this.opReturnDataReader.TryGetTargetAddress(transaction);
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string addressFromOpReturn);
 
             addressFromOpReturn.Should().Be(opReturnAddress.ToString());
         }
@@ -53,7 +53,7 @@ namespace Stratis.FederatedPeg.Tests
 
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
 
-            string opReturnString = this.opReturnDataReader.TryGetTargetAddress(transaction);
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string opReturnString);
 
             opReturnString.Should().BeNull();
         }
@@ -72,7 +72,7 @@ namespace Stratis.FederatedPeg.Tests
             byte[] opReturnBytes2 = Encoding.UTF8.GetBytes(opReturnAddress2.ToString());
             transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnBytes2)));
 
-            string addressFromOpReturn = this.opReturnDataReader.TryGetTargetAddress(transaction);
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string addressFromOpReturn);
             addressFromOpReturn.Should().BeNull();
         }
 
@@ -95,7 +95,7 @@ namespace Stratis.FederatedPeg.Tests
             byte[] randomMessageBytes = Encoding.UTF8.GetBytes("neither hash, nor address");
             transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(randomMessageBytes)));
 
-            string addressFromOpReturn = this.opReturnDataReader.TryGetTargetAddress(transaction);
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string addressFromOpReturn);
             addressFromOpReturn.Should().Be(opReturnValidAddress.ToString());
         }
 
@@ -105,7 +105,7 @@ namespace Stratis.FederatedPeg.Tests
             byte[] opReturnBytes = Encoding.UTF8.GetBytes("neither hash, nor address");
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
 
-            string opReturnString = this.opReturnDataReader.TryGetTargetAddress(transaction);
+            this.opReturnDataReader.TryGetTargetAddress(transaction, out string opReturnString);
 
             opReturnString.Should().BeNull();
         }
@@ -116,7 +116,7 @@ namespace Stratis.FederatedPeg.Tests
             byte[] opReturnBytes = Encoding.UTF8.GetBytes("neither hash, nor address");
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
 
-            string opReturnString = this.opReturnDataReader.TryGetTransactionId(transaction);
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
 
             opReturnString.Should().BeNull();
         }
@@ -135,7 +135,7 @@ namespace Stratis.FederatedPeg.Tests
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes1);
             transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnBytes2)));
 
-            string opReturnString = this.opReturnDataReader.TryGetTransactionId(transaction);
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
 
             opReturnString.Should().BeNull();
         }
@@ -151,7 +151,7 @@ namespace Stratis.FederatedPeg.Tests
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes1);
             transaction.AddOutput(Money.Zero, new Script(OpcodeType.OP_RETURN, Op.GetPushOp(opReturnBytes2)));
 
-            string opReturnString = this.opReturnDataReader.TryGetTransactionId(transaction);
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
 
             opReturnString.Should().NotBeNull();
             opReturnString.Should().Be(new uint256(opReturnBytes1).ToString());
@@ -165,7 +165,7 @@ namespace Stratis.FederatedPeg.Tests
 
             Transaction transaction = this.transactionBuilder.BuildOpReturnTransaction(this.addressHelper.GetNewSourceChainPubKeyAddress(), opReturnBytes);
 
-            string opReturnString = this.opReturnDataReader.TryGetTransactionId(transaction);
+            this.opReturnDataReader.TryGetTransactionId(transaction, out string opReturnString);
 
             opReturnString.Should().NotBeNull();
             opReturnString.Should().Be(new uint256(opReturnBytes).ToString());

--- a/src/Stratis.FederatedPeg.Tests/WithdrawalExtractorTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/WithdrawalExtractorTests.cs
@@ -44,7 +44,7 @@ namespace Stratis.FederatedPeg.Tests
             this.settings.MultiSigRedeemScript.Returns(this.addressHelper.PayToMultiSig);
             this.settings.FederationPublicKeys.Returns(this.addressHelper.MultisigPrivateKeys.Select(k => k.PubKey).ToArray());
 
-            this.opReturnDataReader.TryGetTargetAddress(null).ReturnsForAnyArgs((string)null);
+            this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });
 
             this.transactionBuilder = new TestMultisigTransactionBuilder(this.addressHelper);
 
@@ -193,7 +193,8 @@ namespace Stratis.FederatedPeg.Tests
                 true);
 
             block.AddTransaction(validWithdrawalTransaction);
-            this.opReturnDataReader.TryGetTransactionId(validWithdrawalTransaction).Returns(opReturnDepositId.ToString());
+            this.opReturnDataReader.TryGetTransactionId(validWithdrawalTransaction, out string txId).Returns(callInfo => { callInfo[1] = opReturnDepositId.ToString(); return true; });
+
             return (targetScript, opReturnDepositId, amount, validWithdrawalTransaction);
         }
 


### PR DESCRIPTION
All methods that start with `Try` should return bool that will tell caller was it a success or fail and an out param with the value if it was success