### PR TITLE
Enable fed wallets and tidy up TestBase constructor.

### DIFF
--- a/src/Stratis.FederatedPeg.IntegrationTests/NodeSetupTests.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/NodeSetupTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.FederatedPeg.IntegrationTests.Utils;
@@ -23,6 +24,18 @@ namespace Stratis.FederatedPeg.IntegrationTests
             this.MainAndSideChainNodeMap["fedSide1"].Node.State.Should().Be(CoreNodeState.Running);
             this.MainAndSideChainNodeMap["fedSide2"].Node.State.Should().Be(CoreNodeState.Running);
             this.MainAndSideChainNodeMap["fedSide3"].Node.State.Should().Be(CoreNodeState.Running);
+        }
+
+        [Fact(Skip ="SideChain Nodes starting but can't execute endpoints when enabling wallets - make sure side chains in TestBase are running as normal.")]
+        public void EnableNodeWallets()
+        {
+            this.StartAndConnectNodes();
+
+            string[] ignoreNodes = { "mainUser", "sideUser" };
+
+            this.EnableWallets(this.MainAndSideChainNodeMap.
+                Where(k => !ignoreNodes.Contains(k.Key)).
+                Select(v => v.Value.Node).ToList());
         }
     }
 }

--- a/src/Stratis.FederatedPeg.IntegrationTests/Stratis.FederatedPeg.IntegrationTests.csproj
+++ b/src/Stratis.FederatedPeg.IntegrationTests/Stratis.FederatedPeg.IntegrationTests.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Flurl" Version="2.8.0" />
+    <PackageReference Include="Flurl.Http" Version="2.4.0" />
     <PackageReference Include="NStratis" Version="4.0.0.72" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/src/Stratis.FederatedPeg.IntegrationTests/Utils/TestBase.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/Utils/TestBase.cs
@@ -1,16 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using NBitcoin;
-using Stratis.Bitcoin.IntegrationTests.Common;
-using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
-using Stratis.Bitcoin.Networks;
-using Stratis.FederatedPeg.Features.FederationGateway;
-using Stratis.Sidechains.Networks;
-
-namespace Stratis.FederatedPeg.IntegrationTests.Utils
+﻿namespace Stratis.FederatedPeg.IntegrationTests.Utils
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using FluentAssertions;
+    using Flurl;
+    using Flurl.Http;
+    using NBitcoin;
+    using Stratis.Bitcoin.IntegrationTests.Common;
+    using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+    using Stratis.Bitcoin.Networks;
+    using Stratis.FederatedPeg.Features.FederationGateway;
+    using Stratis.FederatedPeg.Features.FederationGateway.Models;
+    using Stratis.Sidechains.Networks;
+
     public class TestBase : IDisposable
     {
         protected readonly Network mainchainNetwork;
@@ -36,6 +41,7 @@ namespace Stratis.FederatedPeg.IntegrationTests.Utils
         private readonly CoreNode fedSide3;
 
         private const string ConfigSideChain = "sidechain";
+        private const string ConfigAgentPrefix = "agentprefix";
 
         protected enum Chain
         {
@@ -75,27 +81,10 @@ namespace Stratis.FederatedPeg.IntegrationTests.Utils
             this.fedMain3 = this.nodeBuilder.CreateStratisPosNode(this.mainchainNetwork, nameof(this.fedMain3));
 
             this.sidechainNodeBuilder = SidechainNodeBuilder.CreateSidechainNodeBuilder(this);
-
-            this.sidechainNodeBuilder.ConfigParameters.Add(ConfigSideChain, "1");
-            this.sidechainNodeBuilder.ConfigParameters.Add(FederationGatewaySettings.RedeemScriptParam, this.scriptAndAddresses.payToMultiSig.ToString());
-
             this.sideUser = this.nodeBuilder.CreateStratisPosNode(this.sidechainNetwork);
-
-            this.sidechainNodeBuilder.ConfigParameters.Add(FederationGatewaySettings.PublicKeyParam, this.pubKeysByMnemonic[this.mnemonics[0]].ToString());
             this.fedSide1 = this.sidechainNodeBuilder.CreateSidechainNode(this.sidechainNetwork, this.sidechainNetwork.FederationKeys[0]);
-
-            this.sidechainNodeBuilder.ConfigParameters.AddOrReplace(FederationGatewaySettings.PublicKeyParam, this.pubKeysByMnemonic[this.mnemonics[1]].ToString());
             this.fedSide2 = this.sidechainNodeBuilder.CreateSidechainNode(this.sidechainNetwork, this.sidechainNetwork.FederationKeys[1]);
-
-            this.sidechainNodeBuilder.ConfigParameters.AddOrReplace(FederationGatewaySettings.PublicKeyParam, this.pubKeysByMnemonic[this.mnemonics[2]].ToString());
             this.fedSide3 = this.sidechainNodeBuilder.CreateSidechainNode(this.sidechainNetwork, this.sidechainNetwork.FederationKeys[2]);
-
-            this.ApplyFederationIPs(this.fedMain1, this.fedMain2, this.fedMain3);
-            this.ApplyFederationIPs(this.fedSide1, this.fedSide2, this.fedSide3);
-
-            this.ApplyCounterChainAPIPort(this.fedMain1, this.fedSide1);
-            this.ApplyCounterChainAPIPort(this.fedMain2, this.fedSide2);
-            this.ApplyCounterChainAPIPort(this.fedMain3, this.fedSide3);
 
             this.MainAndSideChainNodeMap = new Dictionary<string, NodeChain>()
             {
@@ -108,6 +97,8 @@ namespace Stratis.FederatedPeg.IntegrationTests.Utils
                 { nameof(this.fedSide2), new NodeChain(this.fedSide2, Chain.Side) },
                 { nameof(this.fedSide3), new NodeChain(this.fedSide3, Chain.Side) }
             };
+
+            this.ApplyConfigParametersToNodes();
         }
 
         protected (Script payToMultiSig, BitcoinAddress sidechainMultisigAddress, BitcoinAddress mainchainMultisigAddress)
@@ -190,9 +181,28 @@ namespace Stratis.FederatedPeg.IntegrationTests.Utils
             }
         }
 
-        private void CreateNodesWithExtraConfig()
+        protected void EnableWallets(List<CoreNode> nodes)
         {
+            this.MainAndSideChainNodeMap["fedMain3"].Node.State.Should().Be(CoreNodeState.Running);
+            this.MainAndSideChainNodeMap["fedMain2"].Node.State.Should().Be(CoreNodeState.Running);
 
+            nodes.ForEach(node =>
+            {
+                this.federationMemberIndexes.ForEach(i =>
+                {
+                    $"http://localhost:{node.ApiPort}/api".AppendPathSegment("FederationWallet/import-key").PostJsonAsync(new ImportMemberKeyRequest
+                    {
+                        Mnemonic = this.mnemonics[i].ToString(),
+                        Password = "password"
+                    }).Result.StatusCode.Should().Be(HttpStatusCode.OK);
+
+                    $"http://localhost:{node.ApiPort}/api".AppendPathSegment("FederationWallet/enable-federation").PostJsonAsync(new EnableFederationRequest
+                    {
+                        Password = "password"
+                    }).Result.StatusCode.Should().Be(HttpStatusCode.OK);
+                });
+
+            });
         }
 
         private void ApplyFederationIPs(CoreNode fed1, CoreNode fed2, CoreNode fed3)
@@ -217,6 +227,33 @@ namespace Stratis.FederatedPeg.IntegrationTests.Utils
             {
                 sw.WriteLine(configKeyValueIten);
             }
+        }
+
+        private void ApplyConfigParametersToNodes()
+        {
+            this.AppendToConfig(this.fedSide1, $"{ConfigSideChain}=1");
+            this.AppendToConfig(this.fedSide2, $"{ConfigSideChain}=1");
+            this.AppendToConfig(this.fedSide3, $"{ConfigSideChain}=1");
+
+            this.AppendToConfig(this.fedSide1, $"{FederationGatewaySettings.RedeemScriptParam}={this.scriptAndAddresses.payToMultiSig.ToString()}");
+            this.AppendToConfig(this.fedSide2, $"{FederationGatewaySettings.RedeemScriptParam}={this.scriptAndAddresses.payToMultiSig.ToString()}");
+            this.AppendToConfig(this.fedSide3, $"{FederationGatewaySettings.RedeemScriptParam}={this.scriptAndAddresses.payToMultiSig.ToString()}");
+
+            this.AppendToConfig(this.fedSide1, $"{FederationGatewaySettings.PublicKeyParam}={this.pubKeysByMnemonic[this.mnemonics[0]].ToString()}");
+            this.AppendToConfig(this.fedSide2, $"{FederationGatewaySettings.PublicKeyParam}={this.pubKeysByMnemonic[this.mnemonics[1]].ToString()}");
+            this.AppendToConfig(this.fedSide3, $"{FederationGatewaySettings.PublicKeyParam}={this.pubKeysByMnemonic[this.mnemonics[2]].ToString()}");
+
+            this.ApplyFederationIPs(this.fedMain1, this.fedMain2, this.fedMain3);
+            this.ApplyFederationIPs(this.fedSide1, this.fedSide2, this.fedSide3);
+
+            this.ApplyCounterChainAPIPort(this.fedMain1, this.fedSide1);
+            this.ApplyCounterChainAPIPort(this.fedMain2, this.fedSide2);
+            this.ApplyCounterChainAPIPort(this.fedMain3, this.fedSide3);
+
+            this.MainAndSideChainNodeMap.ToList().ForEach(n =>
+            {
+                this.AppendToConfig(n.Value.Node, $"{ConfigAgentPrefix}={n.Key}");
+            });
         }
 
         public void Dispose()

--- a/src/Stratis.FederatedPeg.IntegrationTests/Utils/TestBase.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/Utils/TestBase.cs
@@ -201,9 +201,8 @@
                         Password = "password"
                     }).Result.StatusCode.Should().Be(HttpStatusCode.OK);
                 });
-
             });
-        }
+        }|
 
         private void ApplyFederationIPs(CoreNode fed1, CoreNode fed2, CoreNode fed3)
         {


### PR DESCRIPTION
Integration `TestBase` class now has functionality to enable federated member wallets.

Currently, when running the test to enable wallets the web api endpoint returns a **404 not found** for sidechain nodes.  

I will investigate why but wanted to get this PR in so we can then include private keys for sidechain mining - similar to what is generated in the power shell script :  

![image](https://user-images.githubusercontent.com/16000683/49951655-549e4780-fef2-11e8-9bf4-2e530de53d8a.png)
