### PR TITLE
[WIP] Add block time to cross-chain transactions

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IDeposit.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IDeposit.cs
@@ -37,5 +37,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// </summary>
         [JsonConverter(typeof(UInt256JsonConverter))]
         uint256 BlockHash { get; }
+
+        /// <summary>
+        /// The timestamp of the block where the source deposit has been persisted.
+        /// </summary>
+        uint BlockTime { get; }
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IDepositExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IDepositExtractor.cs
@@ -24,8 +24,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// <param name="transaction">The transaction to extract deposits from.</param>
         /// <param name="blockHeight">The block height of the block containing the transaction.</param>
         /// <param name="blockHash">The block hash of the block containing the transaction.</param>
+        /// <param name="blockTime">The block timestamp of the block containing the transaction.</param>
         /// <returns>The extracted deposit (if any), otherwise <c>null</c>.</returns>
-        IDeposit ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash);
+        IDeposit ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash, uint blockTime);
 
         /// <summary>
         /// Gets deposits from the newly matured block.

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IMaturedBlock.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IMaturedBlock.cs
@@ -7,5 +7,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         uint256 BlockHash { get; }
 
         int BlockHeight { get; }
+
+        uint BlockTime { get; }
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IWithdrawal.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IWithdrawal.cs
@@ -44,5 +44,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// </summary>
         [JsonConverter(typeof(UInt256JsonConverter))]
         uint256 BlockHash { get; }
+
+        /// <summary>
+        /// The timestamp of the block where the target deposit has been persisted.
+        /// </summary>
+        uint BlockTime { get; }
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IWithdrawalExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IWithdrawalExtractor.cs
@@ -11,6 +11,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
     public interface IWithdrawalExtractor
     {
         IReadOnlyList<IWithdrawal> ExtractWithdrawalsFromBlock(Block block, int blockHeight);
-        IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight);
+        IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight, uint blockTime);
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Models/MaturedBlockModel.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Models/MaturedBlockModel.cs
@@ -8,7 +8,7 @@ using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
 namespace Stratis.FederatedPeg.Features.FederationGateway.Models
 {
     /// <summary>
-    /// An instance of this class represents a particular block hash and associated height on the source chain.
+    /// An instance of this class represents a particular block hash and associated height & timestamp on the source chain.
     /// </summary>
     public class MaturedBlockModel : RequestModel, IMaturedBlock
     {
@@ -18,5 +18,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Models
 
         [Required(ErrorMessage = "A block height is required")]
         public int BlockHeight { get; set; }
+
+        [Required(ErrorMessage = "A block time is required")]
+        public uint BlockTime { get; set; }
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/Deposit.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/Deposit.cs
@@ -6,13 +6,14 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
 {
     public class Deposit : IDeposit
     {
-        public Deposit(uint256 id, Money amount, string targetAddress, int blockNumber, uint256 blockHash)
+        public Deposit(uint256 id, Money amount, string targetAddress, int blockNumber, uint256 blockHash, uint blockTime)
         {
             this.Id = id;
             this.Amount = amount;
             this.TargetAddress = targetAddress;
             this.BlockNumber = blockNumber;
             this.BlockHash = blockHash;
+            this.BlockTime = blockTime;
         }
 
         /// <inheritdoc />
@@ -29,6 +30,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
 
         /// <inheritdoc />
         public uint256 BlockHash { get; }
+
+        /// <inheritdoc />
+        public uint BlockTime { get; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/DepositExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/DepositExtractor.cs
@@ -44,7 +44,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
 
             foreach (Transaction transaction in block.Transactions)
             {
-                IDeposit deposit = ExtractDepositFromTransaction(transaction, blockHeight, blockHash);
+                IDeposit deposit = ExtractDepositFromTransaction(transaction, blockHeight, blockHash, block.Header.Time);
                 if (deposit != null)
                 {
                     deposits.Add(deposit);
@@ -55,7 +55,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
         }
 
         /// <inheritdoc />
-        public IDeposit ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash)
+        public IDeposit ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash, uint blockTime)
         {
             List<TxOut> depositsToMultisig = transaction.Outputs.Where(output =>
                 output.ScriptPubKey == this.depositScript
@@ -70,7 +70,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
             this.logger.LogInformation("Processing received transaction with address: {0}. Transaction hash: {1}.",
                 targetAddress, transaction.GetHash());
 
-            return new Deposit(transaction.GetHash(), depositsToMultisig.Sum(o => o.Value), targetAddress, blockHeight, blockHash);
+            return new Deposit(transaction.GetHash(), depositsToMultisig.Sum(o => o.Value), targetAddress, blockHeight, blockHash, blockTime);
         }
 
         public IMaturedBlockDeposits ExtractBlockDeposits(ChainedHeader newlyMaturedBlock)
@@ -80,7 +80,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
             var maturedBlock = new MaturedBlockModel()
             {
                 BlockHash = newlyMaturedBlock.HashBlock,
-                BlockHeight = newlyMaturedBlock.Height
+                BlockHeight = newlyMaturedBlock.Height,
+                BlockTime = newlyMaturedBlock.Header.Time
             };
 
             IReadOnlyList<IDeposit> deposits =

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
@@ -333,7 +333,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             }
         }
 
-        private Transaction BuildDeterministicTransaction(uint256 depositId, Recipient recipient)
+        private Transaction BuildDeterministicTransaction(uint256 depositId, Recipient recipient, uint timeStamp)
         {
             try
             {
@@ -350,7 +350,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
                     Shuffle = false,
                     IgnoreVerify = true,
                     WalletPassword = walletPassword,
-                    Sign = (walletPassword ?? "") != ""
+                    Sign = (walletPassword ?? "") != "",
+                    Time = timeStamp
                 };
 
                 // Build the transaction.
@@ -486,7 +487,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
                                     ScriptPubKey = scriptPubKey
                                 };
 
-                                transaction = BuildDeterministicTransaction(deposit.Id, recipient);
+                                transaction = BuildDeterministicTransaction(deposit.Id, recipient, deposit.BlockTime);
 
                                 if (transaction != null)
                                 {

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/Withdrawal.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/Withdrawal.cs
@@ -6,7 +6,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 {
     public class Withdrawal : IWithdrawal
     {
-        public Withdrawal(uint256 depositId, uint256 id, Money amount, string targetAddress, int blockNumber, uint256 blockHash)
+        public Withdrawal(uint256 depositId, uint256 id, Money amount, string targetAddress, int blockNumber, uint256 blockHash, uint blockTime)
         {
             this.DepositId = depositId;
             this.Id = id;
@@ -14,6 +14,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             this.TargetAddress = targetAddress;
             this.BlockNumber = blockNumber;
             this.BlockHash = blockHash;
+            this.BlockTime = blockTime;
         }
 
         /// <inheritdoc />
@@ -33,6 +34,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
         /// <inheritdoc />
         public uint256 BlockHash { get; }
+
+        /// <inheritdoc />
+        public uint BlockTime { get; }
 
         public override string ToString()
         {

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalExtractor.cs
@@ -35,7 +35,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             var withdrawals = new List<IWithdrawal>();
             foreach (Transaction transaction in block.Transactions)
             {
-                IWithdrawal withdrawal = ExtractWithdrawalFromTransaction(transaction, block.GetHash(), blockHeight);
+                IWithdrawal withdrawal = ExtractWithdrawalFromTransaction(transaction, block.GetHash(), blockHeight, block.Header.Time);
                 if (withdrawal != null) withdrawals.Add(withdrawal);
             }
 
@@ -44,7 +44,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
             return withdrawalsFromBlock;
         }
 
-        public IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight)
+        public IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight, uint blockTime)
         {
             if (transaction.Outputs.Count(this.IsTargetAddressCandidate) != 1) return null;
             if (!IsOnlyFromMultisig(transaction)) return null;
@@ -64,7 +64,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
                 targetAddressOutput.Value,
                 targetAddressOutput.ScriptPubKey.GetScriptAddress(this.network).ToString(),
                 blockHeight,
-                blockHash);
+                blockHash,
+                blockTime);
+
             return withdrawal;
         }
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
@@ -402,7 +402,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
             lock (this.lockObject)
             {
                 // Extract the withdrawal from the transaction (if any).
-                IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(transaction, block?.GetHash(), blockHeight ?? 0);
+                IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(transaction, block?.GetHash(), blockHeight ?? 0, block.Header.Time);
                 if (withdrawal != null)
                 {
                     // Exit if already present and included in a block.
@@ -821,7 +821,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
                 foreach (TransactionData transactionData in this.Wallet.MultiSigAddress.Transactions)
                 {
                     Transaction walletTran = transactionData.GetFullTransaction(this.network);
-                    IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(walletTran, transactionData.BlockHash, transactionData.BlockHeight ?? 0);
+
+                    uint blockTime = this.chain.GetBlock(transactionData.BlockHash).Header.Time;
+
+                    IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(walletTran, transactionData.BlockHash, transactionData.BlockHeight ?? 0, blockTime);
                     if (withdrawal == null)
                         continue;
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletTransactionHandler.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletTransactionHandler.cs
@@ -102,6 +102,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
 
             context.TransactionBuilder = new TransactionBuilder(this.network);
 
+            this.SetTimeStamp(context);
             this.AddRecipients(context);
             this.AddOpReturnOutput(context);
             this.AddCoins(context);
@@ -316,6 +317,13 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
             Script opReturnScript = TxNullDataTemplate.Instance.GenerateScriptPubKey(context.OpReturnData);
             context.TransactionBuilder.Send(opReturnScript, Money.Zero);
         }
+
+        private void SetTimeStamp(TransactionBuildContext context)
+        {
+            if (context.Time == null) return;
+
+            context.TransactionBuilder.SetTimeStamp(context.Time);
+        }
     }
 
     public class TransactionBuildContext
@@ -454,6 +462,11 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
         /// If true, do not perform verification on the built transaction (e.g. it is partially signed)
         /// </summary>
         public bool IgnoreVerify { get; set; }
+
+        /// <summary>
+        /// Override the timestamp of the transaction, normally it defaults to the current time.
+        /// </summary>
+        public uint Time { get; set; }
     }
 
     /// <summary>

--- a/src/Stratis.FederatedPeg.Tests/EventsPersisterTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/EventsPersisterTests.cs
@@ -48,7 +48,8 @@ namespace Stratis.FederatedPeg.Tests
             deposits.Add(new[] { new MaturedBlockDepositsModel(new MaturedBlockModel()
             {
                 BlockHash = 0,
-                BlockHeight = 0
+                BlockHeight = 0,
+                BlockTime = 0
             }, TestingValues.GetMaturedBlockDeposits(depositCount, new HashHeightPair(0, 0)).Deposits)});
 
             IObservable<IMaturedBlockDeposits[]> maturedBlockStream = deposits.ToObservable();
@@ -76,7 +77,8 @@ namespace Stratis.FederatedPeg.Tests
             deposits.Add(new[] { new MaturedBlockDepositsModel(new MaturedBlockModel()
             {
                 BlockHash = 0,
-                BlockHeight = 0
+                BlockHeight = 0,
+                BlockTime = 0
             }, TestingValues.GetMaturedBlockDeposits(depositCount, new HashHeightPair(0, 0)).Deposits)});
 
             IObservable<IMaturedBlockDeposits[]> maturedBlockStream = deposits.ToObservable();
@@ -105,7 +107,8 @@ namespace Stratis.FederatedPeg.Tests
                 deposits.Add(new[] { new MaturedBlockDepositsModel(new MaturedBlockModel()
                 {
                     BlockHash = new uint256((ulong)i),
-                    BlockHeight = i
+                    BlockHeight = i,
+                    BlockTime = (uint)i
                 }, TestingValues.GetMaturedBlockDeposits(i, new HashHeightPair((uint)i, i)).Deposits)});
 
             IObservable<IMaturedBlockDeposits[]> maturedBlockStream = deposits.ToObservable();

--- a/src/Stratis.FederatedPeg.Tests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/FederationGatewayControllerTests.cs
@@ -208,7 +208,7 @@ namespace Stratis.FederatedPeg.Tests
 
             HashHeightPair hashHeightPair = TestingValues.GetHashHeightPair();
             var deposits = new MaturedBlockDepositsModel(new MaturedBlockModel()
-                { BlockHash = hashHeightPair.Hash, BlockHeight = hashHeightPair.Height },
+                { BlockHash = hashHeightPair.Hash, BlockHeight = hashHeightPair.Height, BlockTime = 0 },
                 new[] { new Deposit(0, Money.COIN * 10000, "TTMM7qGGxD5c77pJ8puBg7sTLAm2zZNBwK",
                     hashHeightPair.Height, hashHeightPair.Hash) });
 

--- a/src/Stratis.FederatedPeg.Tests/Utils/TestingValues.cs
+++ b/src/Stratis.FederatedPeg.Tests/Utils/TestingValues.cs
@@ -64,7 +64,7 @@ namespace Stratis.FederatedPeg.Tests.Utils
             IEnumerable<IDeposit> deposits = Enumerable.Range(0, depositCount).Select(_ => GetDeposit(hashHeightPair));
 
             var maturedBlockDeposits = new MaturedBlockDepositsModel(
-                new MaturedBlockModel() { BlockHash = hashHeightPair.Hash, BlockHeight = hashHeightPair.Height },
+                new MaturedBlockModel() { BlockHash = hashHeightPair.Hash, BlockHeight = hashHeightPair.Height, BlockTime = 0},
                 deposits.ToList());
             return maturedBlockDeposits;
         }


### PR DESCRIPTION
This needs #2963 from SBFN before it will compile, so it is not properly tested yet.

This change is necessary because federation members sending funds from the mainchain multisig need to all use the same timestamp when constructing the partial transactions. If this is not done they can generate mutually incompatible signatures that cannot be combined.