### PR TITLE
Explicitly specify minimum protocol versions

### DIFF
--- a/src/Stratis.FederationGatewayD/Program.cs
+++ b/src/Stratis.FederationGatewayD/Program.cs
@@ -57,7 +57,10 @@ namespace Stratis.FederationGatewayD
 
         private static IFullNode GetMainchainFullNode(string[] args)
         {
-            var nodeSettings = new NodeSettings(networksSelector: Networks.Stratis, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args);
+            var nodeSettings = new NodeSettings(networksSelector: Networks.Stratis, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args)
+            {
+                MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION
+            };
 
             IFullNode node = new FullNodeBuilder()
                 .AddCommonFeatures(nodeSettings)
@@ -71,7 +74,10 @@ namespace Stratis.FederationGatewayD
 
         private static IFullNode GetSidechainFullNode(string[] args)
         {
-            var nodeSettings = new NodeSettings(networksSelector: FederatedPegNetwork.NetworksSelector, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION, args: args);
+            var nodeSettings = new NodeSettings(networksSelector: FederatedPegNetwork.NetworksSelector, protocolVersion: ProtocolVersion.ALT_PROTOCOL_VERSION, args: args)
+            {
+                MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION
+            };
 
             IFullNode node = new FullNodeBuilder()
                 .AddCommonFeatures(nodeSettings)


### PR DESCRIPTION
Was getting this a lot on the mainchain federation nodes:

```
info: Stratis.Bitcoin.Connection.ConnectionManagerBehavior[0]
      Peer '[::ffff:13.64.76.48]:26178' offline, reason: 'The peer does not support the required services requirement, reason: peer version is too low'.
```