### PR TITLE
NuGet update and Dbreeze serialization fix

### DIFF
--- a/src/FedKeyPairGen/FederationSetup.csproj
+++ b/src/FedKeyPairGen/FederationSetup.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="NStratis" Version="4.0.0.73" />
-    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.3-beta" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Stratis.FederatedPeg.Features.FederationGateway.csproj
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Stratis.FederatedPeg.Features.FederationGateway.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Polly" Version="6.1.2" />
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Notifications" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Notifications" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.0.3-beta" />
     <PackageReference Include="Tracer.Fody" Version="2.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Stratis.FederatedPeg.IntegrationTests/Stratis.FederatedPeg.IntegrationTests.csproj
+++ b/src/Stratis.FederatedPeg.IntegrationTests/Stratis.FederatedPeg.IntegrationTests.csproj
@@ -16,11 +16,11 @@
     <PackageReference Include="NStratis" Version="4.0.0.73" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.PoA.IntegrationTests.Common" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.IntegrationTests.Common" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.PoA.IntegrationTests.Common" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.IntegrationTests.Common" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.3-beta" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/src/Stratis.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -46,6 +46,7 @@ namespace Stratis.FederatedPeg.Tests
         protected IAsyncLoopFactory asyncLoopFactory;
         protected INodeLifetime nodeLifetime;
         protected IConnectionManager connectionManager;
+        protected DBreezeSerializer dBreezeSerializer;
         protected Dictionary<uint256, Block> blockDict;
         protected List<Transaction> fundingTransactions;
         protected FederationWallet wallet;
@@ -67,9 +68,6 @@ namespace Stratis.FederatedPeg.Tests
             this.network = FederatedPegNetwork.NetworksSelector.Regtest();
             NetworkRegistration.Register(this.network);
 
-            var serializer = new DBreezeSerializer();
-            serializer.Initialize(this.network);
-
             this.loggerFactory = Substitute.For<ILoggerFactory>();
             this.logger = Substitute.For<ILogger>();
             this.asyncLoopFactory = new AsyncLoopFactory(this.loggerFactory);
@@ -84,6 +82,7 @@ namespace Stratis.FederatedPeg.Tests
             this.walletFeePolicy = Substitute.For<IWalletFeePolicy>();
             this.nodeLifetime = new NodeLifetime();
             this.connectionManager = Substitute.For<IConnectionManager>();
+            this.dBreezeSerializer = new DBreezeSerializer(this.network);
 
             this.wallet = null;
             this.federationGatewaySettings = Substitute.For<IFederationGatewaySettings>();
@@ -200,7 +199,7 @@ namespace Stratis.FederatedPeg.Tests
         protected ICrossChainTransferStore CreateStore()
         {
             return new CrossChainTransferStore(this.network, this.dataFolder, this.chain, this.federationGatewaySettings, this.dateTimeProvider,
-                this.loggerFactory, this.withdrawalExtractor, this.fullNode, this.blockRepository, this.federationWalletManager, this.federationWalletTransactionHandler);
+                this.loggerFactory, this.withdrawalExtractor, this.fullNode, this.blockRepository, this.federationWalletManager, this.federationWalletTransactionHandler, this.dBreezeSerializer);
         }
 
         /// <summary>

--- a/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
+++ b/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="NStratis" Version="4.0.0.73" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.3-beta" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/src/Stratis.FederationGatewayD/Stratis.FederationGatewayD.csproj
+++ b/src/Stratis.FederationGatewayD/Stratis.FederationGatewayD.csproj
@@ -15,14 +15,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.RPC" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.RPC" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.SidechainD/Stratis.SidechainD.csproj
+++ b/src/Stratis.SidechainD/Stratis.SidechainD.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="3.0.0.2-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.3-beta" />
     <PackageReference Include="Stratis.Bitcoin.Features.SmartContracts" Version="0.0.3-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.3-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stratis.SidechainDnsD/Stratis.SidechainDnsD.csproj
+++ b/src/Stratis.SidechainDnsD/Stratis.SidechainDnsD.csproj
@@ -10,16 +10,16 @@
    </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.Dns" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="3.0.0.2-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.2-beta" />
+      <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.Dns" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.MemoryPool" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.Miner" Version="3.0.0.3-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.3-beta" />
       <PackageReference Include="Stratis.Bitcoin.Features.SmartContracts" Version="0.0.3-beta" />
-      <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.2-beta" />
+      <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.3-beta" />
    </ItemGroup>
 
    <ItemGroup>

--- a/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
+++ b/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="NStratis" Version="4.0.0.73" />
-    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.3-beta" />
     <PackageReference Include="Stratis.Bitcoin.Features.SmartContracts" Version="0.0.3-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.2-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.3-beta" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Allows the sidechains repo to serialize everything given the changes to the FN Dbreeze serialization and ultimately allows multiple nodes to run in the one process by removing static dependencies.

I haven't actually connected to the network and completed a transfer yet - if someone could do that it would be ace.