### PR TITLE
Fix a few small issues

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -165,8 +165,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             this.walletSyncManager.Start();
             this.crossChainTransferStore.Start();
             this.partialTransactionRequester.Start();
-            // TODO investiagte why are we doing this. Looks incorrect.
-            this.maturedBlockRequester.GetMoreBlocksAsync().GetAwaiter().GetResult();
 
             // Connect the node to the other federation members.
             foreach (IPEndPoint federationMemberIp in this.federationGatewaySettings.FederationNodeIpEndPoints)

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalExtractor.cs
@@ -74,7 +74,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
                 uint256.Parse(depositId),
                 transaction.GetHash(),
                 targetAddressOutput.Value,
-                targetAddressOutput.ScriptPubKey.GetScriptAddress(this.network).ToString(),
+                targetAddressOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString(),
                 blockHeight,
                 blockHash);
 


### PR DESCRIPTION
Fixes the following:

- Call to `GetMoreBlocksAsync` from `FederationGatewayFeature`. These calls should only happen when the mainchain sends the sidechain a matured block that is ahead of the next expected matured block OR when the sidechain want to expedite matters by immediately requesting more blocks following the processing of a batch of blocks.
- An if statement with commented code that should have been removed completely.
- Removal of wallet transactions associated with suspended transfers.
- Invalid script addresses being displayed in console.