### PR TITLE
Cache results of IsFederationActive (961ms)

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Controllers/FederationWalletController.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Controllers/FederationWalletController.cs
@@ -24,7 +24,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Controllers
         public const string GeneralInfo = "general-info";
         public const string Balance = "balance";
         public const string Sync = "sync";
-        public const string ImportKey = "import-key";
         public const string EnableFederation = "enable-federation";
         public const string RemoveTransactions = "remove-transactions";
     }
@@ -157,34 +156,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Controllers
         }
 
         /// <summary>
-        /// Imports the federation member's mnemonic key.
-        /// </summary>
-        /// <param name="request">The object containing the parameters used to recover a wallet.</param>
-        [Route(FederationWalletRouteEndPoint.ImportKey)]
-        [HttpPost]
-        public IActionResult ImportMemberKey([FromBody]ImportMemberKeyRequest request)
-        {
-            Guard.NotNull(request, nameof(request));
-
-            // checks the request is valid
-            if (!this.ModelState.IsValid)
-            {
-                return BuildErrorResponse(this.ModelState);
-            }
-
-            try
-            {
-                this.walletManager.EnableFederation(request.Password, request.Mnemonic, request.Passphrase, true);
-                return this.Ok();
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
-            }
-        }
-
-        /// <summary>
         /// Provide the federation wallet's credentials so that it can sign transactions.
         /// </summary>
         /// <param name="request">The password of the federation wallet.</param>
@@ -203,7 +174,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Controllers
                     return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Formatting error", string.Join(Environment.NewLine, errors));
                 }
 
-                this.walletManager.EnableFederation(request.Password);
+                this.walletManager.EnableFederation(request.Password, request.Mnemonic, request.Passphrase);
 
                 return this.Ok();
             }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Controllers/FederationWalletController.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Controllers/FederationWalletController.cs
@@ -174,7 +174,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Controllers
 
             try
             {
-                this.walletManager.ImportMemberKey(request.Password, request.Mnemonic, request.Passphrase);
+                this.walletManager.EnableFederation(request.Password, request.Mnemonic, request.Passphrase, true);
                 return this.Ok();
             }
             catch (Exception e)

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Controllers/FederationWalletController.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Controllers/FederationWalletController.cs
@@ -203,19 +203,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Controllers
                     return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Formatting error", string.Join(Environment.NewLine, errors));
                 }
 
-                FederationWallet wallet = this.walletManager.GetWallet();
+                this.walletManager.EnableFederation(request.Password);
 
-                // Check the password
-                try
-                {
-                    Key.Parse(wallet.EncryptedSeed, request.Password, wallet.Network);
-                }
-                catch (Exception ex)
-                {
-                    throw new SecurityException(ex.Message);
-                }
-
-                this.walletManager.Secret = new WalletSecret() { WalletPassword = request.Password };
                 return this.Ok();
             }
             catch (Exception e)

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -228,9 +228,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
                                                     "=============================================".PadLeft(10,'=')
                            + Environment.NewLine
                            + Environment.NewLine +  "Federation node not enabled. You will not be able to sign transactions until you enable it."
-                           + Environment.NewLine + $"If not done previously, please import your private key using "
-                           + Environment.NewLine + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.ImportKey}"
-                           + Environment.NewLine + $"Then enable the wallet using "
+                           + Environment.NewLine + $"If not done previously, please enable your federation node using "
                            + Environment.NewLine + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}"
                            + Environment.NewLine
                            + Environment.NewLine + $"============================================".PadLeft(10, '=')

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
@@ -139,6 +139,12 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         bool IsFederationActive();
 
         /// <summary>
+        /// Enables federation.
+        /// </summary>
+        /// <param name="password">The federation wallet password.</param>
+        void EnableFederation(string password);
+
+        /// <summary>
         /// Removes all the transactions from the federation wallet.
         /// </summary>
         /// <returns>A list of objects made up of transaction IDs along with the time at which they were created.</returns>

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
@@ -136,8 +136,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// <param name="password">The federation wallet password.</param>
         /// <param name="mnemonic">The user's mnemonic.</param>
         /// <param name="passphrase">A passphrase used to derive the private key from the mnemonic.</param>
-        /// <param name="onlyImportKey">If set to <c>true</c> imports the key without activating the federation.</param>
-        void EnableFederation(string password, string mnemonic = null, string passphrase = null, bool onlyImportKey = false);
+        void EnableFederation(string password, string mnemonic = null, string passphrase = null);
 
         /// <summary>
         /// Removes all the transactions from the federation wallet.

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IFederationWalletManager.cs
@@ -103,14 +103,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         WalletSecret Secret { get; set; }
 
         /// <summary>
-        /// Imports the federation member's mnemonic key.
-        /// </summary>
-        /// <param name="password">The user's password.</param>
-        /// <param name="mnemonic">The user's mnemonic.</param>
-        /// <param name="passphrase">A passphrase used to derive the private key from the mnemonic.</param>
-        void ImportMemberKey(string password, string mnemonic, string passphrase);
-
-        /// <summary>
         /// Finds all withdrawal transactions with optional filtering by deposit id or transaction id.
         /// </summary>
         /// <param name="depositId">Filters by this deposit id if not <c>null</c>.</param>
@@ -142,7 +134,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
         /// Enables federation.
         /// </summary>
         /// <param name="password">The federation wallet password.</param>
-        void EnableFederation(string password);
+        /// <param name="mnemonic">The user's mnemonic.</param>
+        /// <param name="passphrase">A passphrase used to derive the private key from the mnemonic.</param>
+        /// <param name="onlyImportKey">If set to <c>true</c> imports the key without activating the federation.</param>
+        void EnableFederation(string password, string mnemonic = null, string passphrase = null, bool onlyImportKey = false);
 
         /// <summary>
         /// Removes all the transactions from the federation wallet.

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Models/RequestModels.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Models/RequestModels.cs
@@ -18,7 +18,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Models
         }
     }
 
-    public class ImportMemberKeyRequest : RequestModel
+    /// <summary>
+    /// Model for the "enablefederation" request.
+    /// </summary>
+    public class EnableFederationRequest : RequestModel
     {
         [Required(ErrorMessage = "A mnemonic is required.")]
         public string Mnemonic { get; set; }
@@ -27,18 +30,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Models
         public string Password { get; set; }
 
         public string Passphrase { get; set; }
-    }
-
-    /// <summary>
-    /// Model for the "enablefederation" request.
-    /// </summary>
-    public class EnableFederationRequest : RequestModel
-    {
-        /// <summary>
-        /// The federation wallet password.
-        /// </summary>
-        [Required(ErrorMessage = "A password is required.")]
-        public string Password { get; set; }
     }
 
     /// <summary>

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/CrossChainTransferStore.cs
@@ -430,8 +430,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
                     this.Synchronize();
 
-                    bool? canPersist = null;
-
                     foreach (MaturedBlockDepositsModel maturedDeposit in maturedBlockDeposits)
                     {
                         if (maturedDeposit.BlockInfo.BlockHeight != this.NextMatureDepositHeight)
@@ -444,12 +442,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
                             continue;
                         }
 
-                        // IsFederationActive is a bit slow. Call it once only.
-                        canPersist = canPersist ?? this.federationWalletManager.IsFederationActive();
-
-                        if (!(bool)canPersist)
+                        if (!this.federationWalletManager.IsFederationActive())
                         {
-                            this.logger.LogError("The store can't persist mature deposits at the moment.");
+                            this.logger.LogError("The store can't persist mature deposits while the federation is inactive.");
                             continue;
                         }
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Wallet/FederationWalletManager.cs
@@ -1023,8 +1023,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
                 if (key == null)
                     key = Key.Parse(encryptedSeed, password, this.Wallet.Network);
 
-                this.isFederationActive = key.PubKey.ToHex() == this.federationGatewaySettings.PublicKey;
-                if (!this.isFederationActive)
+                bool isValidKey = key.PubKey.ToHex() == this.federationGatewaySettings.PublicKey;
+                if (!isValidKey)
                 {
                     this.logger.LogInformation("The wallet public key {0} does not match the federation member's public key {1}", key.PubKey.ToHex(), this.federationGatewaySettings.PublicKey);
                     return;
@@ -1033,6 +1033,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Wallet
                 this.Secret = new WalletSecret() { WalletPassword = password };
                 this.Wallet.EncryptedSeed = encryptedSeed;
                 this.SaveWallet();
+
+                this.isFederationActive = isValidKey;
             }
             catch (Exception ex)
             {

--- a/src/Stratis.FederatedPeg.IntegrationTests/Utils/SidechainTestContext.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/Utils/SidechainTestContext.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Flurl;
@@ -209,15 +208,10 @@ namespace Stratis.FederatedPeg.IntegrationTests.Utils
             {
                 CoreNode node = nodes[i];
 
-                $"http://localhost:{node.ApiPort}/api".AppendPathSegment("FederationWallet/import-key").PostJsonAsync(new ImportMemberKeyRequest
-                {
-                    Mnemonic = this.mnemonics[i].ToString(),
-                    Password = "password"
-                }).Result.StatusCode.Should().Be(HttpStatusCode.OK);
-
                 $"http://localhost:{node.ApiPort}/api".AppendPathSegment("FederationWallet/enable-federation").PostJsonAsync(new EnableFederationRequest
                 {
-                    Password = "password"
+                    Password = "password",
+                    Mnemonic = this.mnemonics[i].ToString()
                 }).Result.StatusCode.Should().Be(HttpStatusCode.OK);
             }
         }

--- a/src/Stratis.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -195,6 +195,11 @@ namespace Stratis.FederatedPeg.Tests
             this.wallet.EncryptedSeed = encryptedSeed;
 
             this.federationWalletManager.Secret = new WalletSecret() { WalletPassword = walletPassword };
+
+            System.Reflection.FieldInfo prop = this.federationWalletManager.GetType().GetField("isFederationActive",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+            prop.SetValue(this.federationWalletManager, true);
         }
 
         protected ICrossChainTransferStore CreateStore()


### PR DESCRIPTION
The IsFederationActive call takes 961 ms (almost a full second). 

This PR adds a cache of parameters / result values.