### PR TITLE
Fix for: Polly prevents node syncing when counter chain API isn't available.

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/LeaderProvider.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/LeaderProvider.cs
@@ -7,7 +7,7 @@ using Stratis.FederatedPeg.Features.FederationGateway.Models;
 namespace Stratis.FederatedPeg.Features.FederationGateway
 {
     /// <summary>
-    /// This class determines which federated member to select as the next leader based on a change in block hieght.
+    /// This class determines which federated member to select as the next leader based on a change in block height.
     /// </summary>
     public interface ILeaderProvider
     {

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Notifications/BlockObserver.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Notifications/BlockObserver.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using NBitcoin;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Signals;
@@ -6,7 +8,6 @@ using Stratis.Bitcoin.Utilities;
 using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
 using Stratis.FederatedPeg.Features.FederationGateway.Models;
 using Stratis.FederatedPeg.Features.FederationGateway.RestClients;
-using Stratis.FederatedPeg.Features.FederationGateway.SourceChain;
 using Stratis.FederatedPeg.Features.FederationGateway.TargetChain;
 
 namespace Stratis.FederatedPeg.Features.FederationGateway.Notifications
@@ -28,6 +29,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Notifications
 
         private readonly IWithdrawalReceiver withdrawalReceiver;
 
+        private CancellationTokenSource cancellationSource;
+
+        private Task pushBlockTipTask;
+
         /// <summary>
         /// Initialize the block observer with the wallet manager and the cross chain monitor.
         /// </summary>
@@ -36,7 +41,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Notifications
         /// <param name="withdrawalExtractor">The component used to extract withdrawals from blocks.</param>
         /// <param name="withdrawalReceiver">The component that receives the withdrawals extracted from blocks.</param>
         /// <param name="federationGatewayClient">Client for federation gateway api.</param>
-        /// <param name="blockTipSender">Service responsible for publishing the block tip.</param>
         public BlockObserver(IFederationWalletSyncManager walletSyncManager,
                              IDepositExtractor depositExtractor,
                              IWithdrawalExtractor withdrawalExtractor,
@@ -54,6 +58,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Notifications
             this.depositExtractor = depositExtractor;
             this.withdrawalExtractor = withdrawalExtractor;
             this.withdrawalReceiver = withdrawalReceiver;
+
+            this.cancellationSource = null;
+            this.pushBlockTipTask = null;
         }
 
         /// <summary>
@@ -64,11 +71,24 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Notifications
         {
             this.walletSyncManager.ProcessBlock(chainedHeaderBlock.Block);
 
-            this.federationGatewayClient.PushCurrentBlockTipAsync(
-                new BlockTipModel(
-                    chainedHeaderBlock.ChainedHeader.HashBlock,
-                    chainedHeaderBlock.ChainedHeader.Height,
-                    (int)this.depositExtractor.MinimumDepositConfirmations)).ConfigureAwait(false).GetAwaiter().GetResult();
+            // Cancel previous sending to avoid first sending new tip and then sending older tip.
+            if ((this.pushBlockTipTask != null) && !this.pushBlockTipTask.IsCompleted)
+            {
+                this.cancellationSource.Cancel();
+                this.pushBlockTipTask.GetAwaiter().GetResult();
+
+                this.pushBlockTipTask = null;
+                this.cancellationSource = null;
+            }
+
+            var blockTipModel = new BlockTipModel(chainedHeaderBlock.ChainedHeader.HashBlock,chainedHeaderBlock.ChainedHeader.Height, (int)this.depositExtractor.MinimumDepositConfirmations);
+
+            // Fire and forget.
+            // There is no reason to wait for the message to be sent.
+            // Awaiting REST API call will only slow this callback.
+            // Callbacks never supposed to do any IO calls or web requests.
+            this.cancellationSource = new CancellationTokenSource();
+            this.pushBlockTipTask = Task.Run(async () => await this.federationGatewayClient.PushCurrentBlockTipAsync(blockTipModel, this.cancellationSource.Token).ConfigureAwait(false));
 
             IReadOnlyList<IWithdrawal> withdrawals = this.withdrawalExtractor.ExtractWithdrawalsFromBlock(
                 chainedHeaderBlock.Block,

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Notifications/BlockObserver.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Notifications/BlockObserver.cs
@@ -83,10 +83,13 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.Notifications
 
             var blockTipModel = new BlockTipModel(chainedHeaderBlock.ChainedHeader.HashBlock,chainedHeaderBlock.ChainedHeader.Height, (int)this.depositExtractor.MinimumDepositConfirmations);
 
-            // Fire and forget.
             // There is no reason to wait for the message to be sent.
             // Awaiting REST API call will only slow this callback.
             // Callbacks never supposed to do any IO calls or web requests.
+            // Instead we start sending the message and if next block was connected faster than the message was sent we
+            // are canceling it and sending the next tip.
+            // Receiver of this message doesn't care if we are not providing tips for every block we connect,
+            // it just requires to know about out latest state.
             this.cancellationSource = new CancellationTokenSource();
             this.pushBlockTipTask = Task.Run(async () => await this.federationGatewayClient.PushCurrentBlockTipAsync(blockTipModel, this.cancellationSource.Token).ConfigureAwait(false));
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/FederationGatewayClient.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/FederationGatewayClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Stratis.FederatedPeg.Features.FederationGateway.Controllers;
@@ -11,10 +12,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
     public interface IFederationGatewayClient
     {
         /// <summary><see cref="FederationGatewayController.PushCurrentBlockTip"/></summary>
-        Task PushCurrentBlockTipAsync(BlockTipModel model);
+        Task PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken));
 
         /// <summary><see cref="FederationGatewayController.GetMaturedBlockDepositsAsync"/></summary>
-        Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model);
+        Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken));
     }
 
     /// <inheritdoc cref="IFederationGatewayClient"/>
@@ -26,15 +27,15 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
         }
 
         /// <inheritdoc />
-        public Task PushCurrentBlockTipAsync(BlockTipModel model)
+        public Task PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken))
         {
-            return this.SendPostRequestAsync(model, FederationGatewayRouteEndPoint.PushCurrentBlockTip);
+            return this.SendPostRequestAsync(model, FederationGatewayRouteEndPoint.PushCurrentBlockTip, cancellation);
         }
 
         /// <inheritdoc />
-        public Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model)
+        public Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken))
         {
-            return this.SendPostRequestAsync<MaturedBlockRequestModel, List<MaturedBlockDepositsModel>>(model, FederationGatewayRouteEndPoint.GetMaturedBlockDeposits);
+            return this.SendPostRequestAsync<MaturedBlockRequestModel, List<MaturedBlockDepositsModel>>(model, FederationGatewayRouteEndPoint.GetMaturedBlockDeposits, cancellation);
         }
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
@@ -38,7 +38,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
             this.policy = Policy.Handle<Exception>().WaitAndRetryAsync(retryCount: RetryCount, sleepDurationProvider: attempt => TimeSpan.FromMilliseconds(AttemptDelayMs), onRetry: OnRetry);
         }
 
-        protected async Task<HttpResponseMessage> SendPostRequestAsync<Model>(Model requestModel, string apiMethodName) where Model : class
+        protected async Task<HttpResponseMessage> SendPostRequestAsync<Model>(Model requestModel, string apiMethodName, CancellationToken cancellation) where Model : class
         {
             var publicationUri = new Uri($"{this.endpointUrl}/{apiMethodName}");
 
@@ -53,12 +53,19 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
                     // Retry the following call according to the policy.
                     await this.policy.ExecuteAsync(async token =>
                     {
-                        this.logger.LogDebug("Sending request of type '{0}' to Uri '{1}'.", requestModel.GetType().FullName, publicationUri);
+                        this.logger.LogDebug("Sending request of type '{0}' to Uri '{1}'.",
+                            requestModel.GetType().FullName, publicationUri);
 
-                        response = await client.PostAsync(publicationUri, request).ConfigureAwait(false);
+                        response = await client.PostAsync(publicationUri, request, cancellation).ConfigureAwait(false);
                         this.logger.LogDebug("Response received: {0}", response);
 
-                    }, CancellationToken.None);
+                    }, cancellation);
+                }
+                catch (OperationCanceledException)
+                {
+                    this.logger.LogError("Operation canceled.");
+                    this.logger.LogTrace("(-)[CANCELED]:null");
+                    return null;
                 }
                 catch (Exception ex)
                 {
@@ -72,9 +79,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
             return response;
         }
 
-        protected async Task<Response> SendPostRequestAsync<Model, Response>(Model requestModel, string apiMethodName) where Response : class where Model : class
+        protected async Task<Response> SendPostRequestAsync<Model, Response>(Model requestModel, string apiMethodName, CancellationToken cancellation) where Response : class where Model : class
         {
-            HttpResponseMessage response = await this.SendPostRequestAsync(requestModel, apiMethodName).ConfigureAwait(false);
+            HttpResponseMessage response = await this.SendPostRequestAsync(requestModel, apiMethodName, cancellation).ConfigureAwait(false);
 
             // Parse response.
             if ((response != null) && response.IsSuccessStatusCode && (response.Content != null))

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
@@ -73,8 +73,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
                 }
                 catch (OperationCanceledException)
                 {
-                    this.logger.LogError("Operation canceled.");
-                    this.logger.LogTrace("(-)[CANCELED]:null");
+                    this.logger.LogDebug("Operation canceled.");
+                    this.logger.LogTrace("(-)[CANCELLED]:null");
                     return null;
                 }
                 catch (Exception ex)

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
@@ -56,10 +56,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         /// <summary>Continuously requests matured blocks from another chain.</summary>
         private async Task RequestMaturedBlocksContinouslyAsync()
         {
-            // Initialization delay.
-            // Give other node some time to start API service.
-            await Task.Delay(RefreshDelayMs).ConfigureAwait(false);
-
             while (!this.cancellation.IsCancellationRequested)
             {
                 bool delayRequired = await this.AskForBlocksAsync().ConfigureAwait(false);

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
@@ -38,6 +38,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         /// <summary>When we are fully synced we stop asking for more blocks for this amount of time.</summary>
         private const int RefreshDelayMs = 10_000;
 
+        /// <summary>Delay between initialization and first request to other node.</summary>
+        /// <remarks>Needed to give other node some time to start before bombing it with requests.</remarks>
+        public const int InitializationDelayMs = 5_000;
+
         public MaturedBlocksSyncManager(ICrossChainTransferStore store, IFederationGatewayClient federationGatewayClient, ILoggerFactory loggerFactory)
         {
             this.store = store;
@@ -56,23 +60,35 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         /// <summary>Continuously requests matured blocks from another chain.</summary>
         private async Task RequestMaturedBlocksContinouslyAsync()
         {
-            while (!this.cancellation.IsCancellationRequested)
+            try
             {
-                bool delayRequired = await this.AskForBlocksAsync().ConfigureAwait(false);
+                // Initialization delay.
+                // Give other node some time to start API service.
+                await Task.Delay(InitializationDelayMs, this.cancellation.Token).ConfigureAwait(false);
 
-                if (delayRequired)
+                while (!this.cancellation.IsCancellationRequested)
                 {
-                    // Since we are synced or had a problem syncing there is no need to ask for more blocks right away.
-                    // Therefore awaiting for a delay during which new block might be accepted on the alternative chain
-                    // or alt chain node might be started.
-                    await Task.Delay(RefreshDelayMs).ConfigureAwait(false);
+                    bool delayRequired = await this.AskForBlocksAsync(this.cancellation.Token).ConfigureAwait(false);
+
+                    if (delayRequired)
+                    {
+                        // Since we are synced or had a problem syncing there is no need to ask for more blocks right away.
+                        // Therefore awaiting for a delay during which new block might be accepted on the alternative chain
+                        // or alt chain node might be started.
+                        await Task.Delay(RefreshDelayMs, this.cancellation.Token).ConfigureAwait(false);
+                    }
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                this.logger.LogTrace("(-)[CANCELLED]");
             }
         }
 
         /// <summary>Asks for blocks from another gateway node and then processes them.</summary>
         /// <returns><c>true</c> if delay between next time we should ask for blocks is required; <c>false</c> otherwise.</returns>
-        protected async Task<bool> AskForBlocksAsync()
+        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled.</exception>
+        protected async Task<bool> AskForBlocksAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             int blocksToRequest = 1;
 
@@ -88,7 +104,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
                 nameof(model.MaxBlocksToSend), model.MaxBlocksToSend);
 
             // Ask for blocks.
-            IList<MaturedBlockDepositsModel> matureBlockDeposits = await this.federationGatewayClient.GetMaturedBlockDepositsAsync(model).ConfigureAwait(false);
+            IList<MaturedBlockDepositsModel> matureBlockDeposits = await this.federationGatewayClient.GetMaturedBlockDepositsAsync(model, cancellationToken).ConfigureAwait(false);
 
             bool delayRequired = true;
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
@@ -56,6 +56,10 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         /// <summary>Continuously requests matured blocks from another chain.</summary>
         private async Task RequestMaturedBlocksContinouslyAsync()
         {
+            // Initialization delay.
+            // Give other node some time to start API service.
+            await Task.Delay(RefreshDelayMs).ConfigureAwait(false);
+
             while (!this.cancellation.IsCancellationRequested)
             {
                 bool delayRequired = await this.AskForBlocksAsync().ConfigureAwait(false);

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
@@ -40,7 +40,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
         /// <summary>Delay between initialization and first request to other node.</summary>
         /// <remarks>Needed to give other node some time to start before bombing it with requests.</remarks>
-        private const int InitializationDelayMs = 5_000;
+        private const int InitializationDelayMs = 10_000;
 
         public MaturedBlocksSyncManager(ICrossChainTransferStore store, IFederationGatewayClient federationGatewayClient, ILoggerFactory loggerFactory)
         {
@@ -68,7 +68,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
                 while (!this.cancellation.IsCancellationRequested)
                 {
-                    bool delayRequired = await this.AskForBlocksAsync(this.cancellation.Token).ConfigureAwait(false);
+                    bool delayRequired = await this.SyncBatchOfBlocksAsync(this.cancellation.Token).ConfigureAwait(false);
 
                     if (delayRequired)
                     {
@@ -87,8 +87,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
         /// <summary>Asks for blocks from another gateway node and then processes them.</summary>
         /// <returns><c>true</c> if delay between next time we should ask for blocks is required; <c>false</c> otherwise.</returns>
-        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is canceled.</exception>
-        protected async Task<bool> AskForBlocksAsync(CancellationToken cancellationToken = default(CancellationToken))
+        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
+        protected async Task<bool> SyncBatchOfBlocksAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             int blocksToRequest = 1;
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
@@ -40,7 +40,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
 
         /// <summary>Delay between initialization and first request to other node.</summary>
         /// <remarks>Needed to give other node some time to start before bombing it with requests.</remarks>
-        public const int InitializationDelayMs = 5_000;
+        private const int InitializationDelayMs = 5_000;
 
         public MaturedBlocksSyncManager(ICrossChainTransferStore store, IFederationGatewayClient federationGatewayClient, ILoggerFactory loggerFactory)
         {

--- a/src/Stratis.FederatedPeg.IntegrationTests/NodeSetupTests.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/NodeSetupTests.cs
@@ -1,13 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using NBitcoin;
 using Stratis.Bitcoin.IntegrationTests.Common;
-using Stratis.Bitcoin.Features.Wallet.Models;
-using Stratis.Bitcoin.IntegrationTests.Common;
-using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
-using Stratis.FederatedPeg.Features.FederationGateway.NetworkHelpers;
 using Stratis.FederatedPeg.IntegrationTests.Utils;
 using Xunit;
 
@@ -18,7 +12,7 @@ namespace Stratis.FederatedPeg.IntegrationTests
         [Fact]
         public void StartBothChainsWithWallets()
         {
-            using (SidechainTestContext context = new SidechainTestContext())
+            using (var context = new SidechainTestContext())
             {
                 context.StartAndConnectNodes();
 
@@ -27,9 +21,10 @@ namespace Stratis.FederatedPeg.IntegrationTests
             }
         }
 
+        [Fact]
         public void FundMainChain()
         {
-            using (SidechainTestContext context = new SidechainTestContext())
+            using (var context = new SidechainTestContext())
             {
                 context.StartMainNodes();
                 context.ConnectMainChainNodes();
@@ -41,9 +36,10 @@ namespace Stratis.FederatedPeg.IntegrationTests
             }
         }
 
+        [Fact]
         public void FundSideChain()
         {
-            using (SidechainTestContext context = new SidechainTestContext())
+            using (var context = new SidechainTestContext())
             {
                 context.StartSideNodes();
                 context.ConnectSideChainNodes();
@@ -65,7 +61,7 @@ namespace Stratis.FederatedPeg.IntegrationTests
         [Fact]
         public async Task MainChain_To_SideChain_Transfer_And_Back()
         {
-            using (SidechainTestContext context = new SidechainTestContext())
+            using (var context = new SidechainTestContext())
             {
                 // Set everything up
                 context.StartAndConnectNodes();
@@ -87,17 +83,25 @@ namespace Stratis.FederatedPeg.IntegrationTests
                 Assert.Equal(context.scriptAndAddresses.payToMultiSig.PaymentScript, coinbase.Outputs[0].ScriptPubKey);
 
                 // Send to sidechain
+                decimal transferValueCoins = 25;
+                var transferValue = new Money(transferValueCoins, MoneyUnit.BTC);
                 string sidechainAddress = context.GetAddress(context.SideUser);
-                await context.DepositToSideChain(context.MainUser, 25, sidechainAddress);
+                await context.DepositToSideChain(context.MainUser, transferValueCoins, sidechainAddress);
                 TestHelper.WaitLoop(() => context.FedMain1.CreateRPCClient().GetRawMempool().Length == 1);
                 TestHelper.MineBlocks(context.FedMain1, 15);
 
-                // Sidechain user has balance - transfer complete
-                Assert.Equal(new Money(25, MoneyUnit.BTC), context.GetBalance(context.SideUser));
+                var source = new CancellationTokenSource(15_000);
+                TestHelper.WaitLoop(() => context.GetBalance(context.SideUser) == transferValue, cancellationToken: source.Token);
+
+                // Sidechain user has balance - transfer complete.
+                Assert.Equal(transferValue, context.GetBalance(context.SideUser));
+
+                await Task.Delay(5_000).ConfigureAwait(false);
 
                 // Send funds back to the main chain
                 string mainchainAddress = context.GetAddress(context.MainUser);
                 Money currentMainUserBalance = context.GetBalance(context.MainUser);
+
                 await context.WithdrawToMainChain(context.SideUser, 24, mainchainAddress);
                 int currentSideHeight = context.SideUser.FullNode.Chain.Tip.Height;
                 // Mine just enough to get past min deposit and allow time for fed to work

--- a/src/Stratis.FederatedPeg.IntegrationTests/NodeSetupTests.cs
+++ b/src/Stratis.FederatedPeg.IntegrationTests/NodeSetupTests.cs
@@ -27,7 +27,6 @@ namespace Stratis.FederatedPeg.IntegrationTests
             }
         }
 
-        [Fact(Skip = "Polly is preventing nodes syncing.")]
         public void FundMainChain()
         {
             using (SidechainTestContext context = new SidechainTestContext())
@@ -42,7 +41,6 @@ namespace Stratis.FederatedPeg.IntegrationTests
             }
         }
 
-        [Fact(Skip = "Polly is preventing nodes syncing.")]
         public void FundSideChain()
         {
             using (SidechainTestContext context = new SidechainTestContext())
@@ -103,7 +101,7 @@ namespace Stratis.FederatedPeg.IntegrationTests
                 await context.WithdrawToMainChain(context.SideUser, 24, mainchainAddress);
                 int currentSideHeight = context.SideUser.FullNode.Chain.Tip.Height;
                 // Mine just enough to get past min deposit and allow time for fed to work
-                TestHelper.WaitLoop(() => context.SideUser.FullNode.Chain.Height >= currentSideHeight + 7); 
+                TestHelper.WaitLoop(() => context.SideUser.FullNode.Chain.Height >= currentSideHeight + 7);
 
                 // Should unlock funds back on the main chain
                 TestHelper.WaitLoop(() => context.FedMain1.CreateRPCClient().GetRawMempool().Length == 1);

--- a/src/Stratis.FederatedPeg.Tests/BlockObserverTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/BlockObserverTests.cs
@@ -82,7 +82,9 @@ namespace Stratis.FederatedPeg.Tests
                 this.federationGatewayClient);
         }
 
-        [Fact]
+        [Retry(3)]
+        // This test requires retries because we are asserting result of a background thread that calls API.
+        // This will work in real life but in tests it produces a race condition and therefore requires retries.
         public async Task BlockObserverShouldNotTryToExtractDepositsBeforeMinimumDepositConfirmationsAsync()
         {
             int confirmations = (int)this.minimumDepositConfirmations - 1;
@@ -96,12 +98,14 @@ namespace Stratis.FederatedPeg.Tests
             this.withdrawalExtractor.ReceivedWithAnyArgs(1).ExtractWithdrawalsFromBlock(earlyBlock, 0);
             this.withdrawalReceiver.Received(1).ReceiveWithdrawals(Arg.Is(this.extractedWithdrawals));
 
-            await Task.Delay(MaturedBlocksSyncManager.InitializationDelayMs).ConfigureAwait(false);
+            await Task.Delay(500).ConfigureAwait(false);
 
             await this.federationGatewayClient.ReceivedWithAnyArgs(1).PushCurrentBlockTipAsync(null);
         }
 
-        [Fact]
+        [Retry(3)]
+        // This test requires retries because we are asserting result of a background thread that calls API.
+        // This will work in real life but in tests it produces a race condition and therefore requires retries.
         public void BlockObserverShouldTryToExtractDepositsAfterMinimumDepositConfirmations()
         {
             (ChainedHeaderBlock chainedHeaderBlock, Block block) blockBuilder = this.ChainHeaderBlockBuilder();
@@ -113,14 +117,16 @@ namespace Stratis.FederatedPeg.Tests
             this.federationGatewayClient.ReceivedWithAnyArgs(1).PushCurrentBlockTipAsync(null);
         }
 
-        [Fact]
+        [Retry(3)]
+        // This test requires retries because we are asserting result of a background thread that calls API.
+        // This will work in real life but in tests it produces a race condition and therefore requires retries.
         public async Task BlockObserverShouldSendBlockTipAsync()
         {
             ChainedHeaderBlock chainedHeaderBlock = this.ChainHeaderBlockBuilder().chainedHeaderBlock;
 
             this.blockObserver.OnNext(chainedHeaderBlock);
 
-            await Task.Delay(MaturedBlocksSyncManager.InitializationDelayMs).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
 
             await this.federationGatewayClient.ReceivedWithAnyArgs(1).PushCurrentBlockTipAsync(null);
         }

--- a/src/Stratis.FederatedPeg.Tests/MaturedBlocksSyncManagerTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/MaturedBlocksSyncManagerTests.cs
@@ -38,21 +38,21 @@ namespace Stratis.FederatedPeg.Tests
             var models = new List<MaturedBlockDepositsModel>() { new MaturedBlockDepositsModel(new MaturedBlockInfoModel(), new List<IDeposit>())};
             this.federationGatewayClient.GetMaturedBlockDepositsAsync(null).ReturnsForAnyArgs(Task.FromResult(models));
 
-            bool delayRequired = await this.syncManager.ExposedAskForBlocksAsync();
+            bool delayRequired = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
             // Delay shouldn't be required because not-empty list was provided.
             Assert.False(delayRequired);
 
             // Now provide empty list.
             this.federationGatewayClient.GetMaturedBlockDepositsAsync(null).ReturnsForAnyArgs(Task.FromResult(new List<MaturedBlockDepositsModel>() {}));
 
-            bool delayRequired2 = await this.syncManager.ExposedAskForBlocksAsync();
+            bool delayRequired2 = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
             // Delay is required because empty list was provided.
             Assert.True(delayRequired2);
 
             // Now provide null.
             this.federationGatewayClient.GetMaturedBlockDepositsAsync(null).ReturnsForAnyArgs(Task.FromResult(null as List<MaturedBlockDepositsModel>));
 
-            bool delayRequired3 = await this.syncManager.ExposedAskForBlocksAsync();
+            bool delayRequired3 = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
             // Delay is required because null list was provided.
             Assert.True(delayRequired3);
         }
@@ -65,9 +65,9 @@ namespace Stratis.FederatedPeg.Tests
             {
             }
 
-            public Task<bool> ExposedAskForBlocksAsync()
+            public Task<bool> ExposedSyncBatchOfBlocksAsync()
             {
-                return this.AskForBlocksAsync();
+                return this.SyncBatchOfBlocksAsync();
             }
         }
     }

--- a/src/Stratis.FederatedPeg.Tests/RestClientsTests/RestApiClientBaseTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/RestClientsTests/RestApiClientBaseTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -52,7 +53,7 @@ namespace Stratis.FederatedPeg.Tests.RestClientsTests
 
         public Task<HttpResponseMessage> CallThatWillAlwaysFail()
         {
-            return this.SendPostRequestAsync("stringModel", "nonExistentAPIMethod");
+            return this.SendPostRequestAsync("stringModel", "nonExistentAPIMethod", CancellationToken.None);
         }
 
         protected override void OnRetry(Exception exception, TimeSpan delay)

--- a/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
+++ b/src/Stratis.FederatedPeg.Tests/Stratis.FederatedPeg.Tests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Stratis.Bitcoin.Tests.Common" Version="3.0.0.3-beta" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="XunitRetry" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added cancellation to REST API client. 
Removed blocking call from OnNextCore callback

Fix: #310