### PR TITLE
Add caching to MaturedBlocksProvider

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/MaturedBlocksProvider.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/MaturedBlocksProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -30,12 +31,15 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
 
         private readonly ILogger logger;
 
+        private Dictionary<int, MaturedBlockDepositsModel> depositCache;
+
         public MaturedBlocksProvider(ILoggerFactory loggerFactory, IDepositExtractor depositExtractor, IConsensusManager consensusManager)
         {
             this.depositExtractor = depositExtractor;
             this.consensusManager = consensusManager;
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.depositCache = new Dictionary<int, MaturedBlockDepositsModel>();
         }
 
         /// <inheritdoc />
@@ -50,18 +54,43 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
                 throw new InvalidOperationException($"Block height {blockHeight} submitted is not mature enough. Blocks less than a height of {matureTipHeight} can be processed.");
             }
 
+            // Cache clean-up.
+            lock (this.depositCache)
+            {
+                // The requested height gives away the fact that the peer is probably no longer interested in cached entries below that height.
+                // Keep an additional 1,000 blocks anyway in case there are some parallel request that are still executing for lower heights.
+                foreach (int i in this.depositCache.Where(d => d.Key < (blockHeight - 1000)).Select(d => d.Key).ToArray())
+                    this.depositCache.Remove(i);
+            }
+
             var maturedBlocks = new List<MaturedBlockDepositsModel>();
 
             for (int i = blockHeight; (i <= matureTipHeight) && (i < blockHeight + maxBlocks); i++)
             {
-                ChainedHeader currentHeader = consensusTip.GetAncestor(i);
+                MaturedBlockDepositsModel maturedBlockDeposits = null;
 
-                ChainedHeaderBlock block = await this.consensusManager.GetBlockDataAsync(currentHeader.HashBlock).ConfigureAwait(false);
+                // First try the cache.
+                lock (this.depositCache)
+                {
+                    this.depositCache.TryGetValue(i, out maturedBlockDeposits);
+                }
 
-                MaturedBlockDepositsModel maturedBlockDeposits = this.depositExtractor.ExtractBlockDeposits(block);
-
+                // If not in cache..
                 if (maturedBlockDeposits == null)
-                    throw new InvalidOperationException($"Unable to get deposits for block at height {currentHeader.Height}");
+                {
+                    ChainedHeader currentHeader = consensusTip.GetAncestor(i);
+                    ChainedHeaderBlock block = await this.consensusManager.GetBlockDataAsync(currentHeader.HashBlock).ConfigureAwait(false);
+                    maturedBlockDeposits = this.depositExtractor.ExtractBlockDeposits(block);
+
+                    if (maturedBlockDeposits == null)
+                        throw new InvalidOperationException($"Unable to get deposits for block at height {currentHeader.Height}");
+
+                    // Save this so that we don't need to scan the block again.
+                    lock (this.depositCache)
+                    {
+                        this.depositCache[i] = maturedBlockDeposits;
+                    }
+                }
 
                 maturedBlocks.Add(maturedBlockDeposits);
             }


### PR DESCRIPTION
When the MaturedBlocksProvider gets a bit slow the counter-chain node may give up and initiate duplicate requests to get blocks of deposits. This PR ensures that no additional work will be done to extract deposits from blocks when that happens. This prevents the source from locking up due to more and more work piling up.