### PR TITLE
Removed cache from MaturedBlocksProvider and reduced batch side, added 60s timeout

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/FederationGatewayClient.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/FederationGatewayClient.cs
@@ -12,7 +12,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
     public interface IFederationGatewayClient
     {
         /// <summary><see cref="FederationGatewayController.PushCurrentBlockTip"/></summary>
-        Task PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken));
+        Task<HttpResponseMessage> PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken));
 
         /// <summary><see cref="FederationGatewayController.GetMaturedBlockDepositsAsync"/></summary>
         Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken));
@@ -27,7 +27,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
         }
 
         /// <inheritdoc />
-        public Task PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken))
+        public Task<HttpResponseMessage> PushCurrentBlockTipAsync(BlockTipModel model, CancellationToken cancellation = default(CancellationToken))
         {
             return this.SendPostRequestAsync(model, FederationGatewayRouteEndPoint.PushCurrentBlockTip, cancellation);
         }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
@@ -26,7 +26,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
         /// <summary>Delay between retries.</summary>
         private const int AttemptDelayMs = 1000;
 
-        private const int TimeoutMs = 60_000;
+        public const int TimeoutMs = 60_000;
 
         private readonly RetryPolicy policy;
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
@@ -52,6 +52,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
 
         protected async Task<HttpResponseMessage> SendPostRequestAsync<Model>(Model requestModel, string apiMethodName, CancellationToken cancellation) where Model : class
         {
+            if (requestModel == null)
+                throw new ArgumentException($"{nameof(requestModel)} can't be null.");
+
             var publicationUri = new Uri($"{this.endpointUrl}/{apiMethodName}");
 
             HttpResponseMessage response = null;
@@ -59,9 +62,6 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
             using (HttpClient client = this.httpClientFactory.CreateClient())
             {
                 client.Timeout = TimeSpan.FromMilliseconds(TimeoutMs);
-
-                if (requestModel == null)
-                    throw new ArgumentException($"{nameof(requestModel)} can't be null.");
 
                 var request = new JsonContent(requestModel);
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
@@ -80,7 +80,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
                 catch (Exception ex)
                 {
                     this.logger.LogError("The counter-chain daemon is not ready to receive API calls at this time ({0})", publicationUri);
-                    this.logger.LogDebug(ex, "Failed to send {0}", requestModel);
+                    this.logger.LogError("Failed to send a message. Exception: '{0}'.", ex);
                     return new HttpResponseMessage() { ReasonPhrase = ex.Message, StatusCode = HttpStatusCode.InternalServerError };
                 }
             }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/MaturedBlocksProvider.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/MaturedBlocksProvider.cs
@@ -71,7 +71,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
 
                 maturedBlocks.Add(maturedBlockDeposits);
 
-                if (cancellation.IsCancellationRequested && maturedBlocks.Count > 1)
+                if (cancellation.IsCancellationRequested && maturedBlocks.Count > 0)
                 {
                     this.logger.LogDebug("Stop matured blocks collection because it's taking too long. Send what we've collected.");
                     break;

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/MaturedBlocksProvider.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/SourceChain/MaturedBlocksProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -31,15 +30,12 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
 
         private readonly ILogger logger;
 
-        private Dictionary<int, MaturedBlockDepositsModel> depositCache;
-
         public MaturedBlocksProvider(ILoggerFactory loggerFactory, IDepositExtractor depositExtractor, IConsensusManager consensusManager)
         {
             this.depositExtractor = depositExtractor;
             this.consensusManager = consensusManager;
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            this.depositCache = new Dictionary<int, MaturedBlockDepositsModel>();
         }
 
         /// <inheritdoc />
@@ -54,51 +50,20 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.SourceChain
                 throw new InvalidOperationException($"Block height {blockHeight} submitted is not mature enough. Blocks less than a height of {matureTipHeight} can be processed.");
             }
 
-            // Cache clean-up.
-            lock (this.depositCache)
-            {
-                // The requested height gives away the fact that the peer is probably no longer interested in cached entries below that height.
-                // Keep an additional 1,000 blocks anyway in case there are some parallel request that are still executing for lower heights.
-                foreach (int i in this.depositCache.Where(d => d.Key < (blockHeight - 1000)).Select(d => d.Key).ToArray())
-                    this.depositCache.Remove(i);
-            }
-
             var maturedBlocks = new List<MaturedBlockDepositsModel>();
-
-            // Don't spend to much time that the requester may give up.
-            DateTime deadLine = DateTime.Now.AddSeconds(30);
 
             for (int i = blockHeight; (i <= matureTipHeight) && (i < blockHeight + maxBlocks); i++)
             {
-                MaturedBlockDepositsModel maturedBlockDeposits = null;
+                ChainedHeader currentHeader = consensusTip.GetAncestor(i);
 
-                // First try the cache.
-                lock (this.depositCache)
-                {
-                    this.depositCache.TryGetValue(i, out maturedBlockDeposits);
-                }
+                ChainedHeaderBlock block = await this.consensusManager.GetBlockDataAsync(currentHeader.HashBlock).ConfigureAwait(false);
 
-                // If not in cache..
+                MaturedBlockDepositsModel maturedBlockDeposits = this.depositExtractor.ExtractBlockDeposits(block);
+
                 if (maturedBlockDeposits == null)
-                {
-                    ChainedHeader currentHeader = consensusTip.GetAncestor(i);
-                    ChainedHeaderBlock block = await this.consensusManager.GetBlockDataAsync(currentHeader.HashBlock).ConfigureAwait(false);
-                    maturedBlockDeposits = this.depositExtractor.ExtractBlockDeposits(block);
-
-                    if (maturedBlockDeposits == null)
-                        throw new InvalidOperationException($"Unable to get deposits for block at height {currentHeader.Height}");
-
-                    // Save this so that we don't need to scan the block again.
-                    lock (this.depositCache)
-                    {
-                        this.depositCache[i] = maturedBlockDeposits;
-                    }
-                }
+                    throw new InvalidOperationException($"Unable to get deposits for block at height {currentHeader.Height}");
 
                 maturedBlocks.Add(maturedBlockDeposits);
-
-                if (DateTime.Now >= deadLine)
-                    break;
             }
 
             return maturedBlocks;

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/MaturedBlocksSyncManager.cs
@@ -33,7 +33,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
         private Task blockRequestingTask;
 
         /// <summary>The maximum amount of blocks to request at a time from alt chain.</summary>
-        private const int MaxBlocksToRequest = 1000;
+        private const int MaxBlocksToRequest = 100;
 
         /// <summary>When we are fully synced we stop asking for more blocks for this amount of time.</summary>
         private const int RefreshDelayMs = 10_000;

--- a/src/Stratis.FederatedPeg.Tests/RestClientsTests/FederationGatewayClientTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/RestClientsTests/FederationGatewayClientTests.cs
@@ -60,9 +60,8 @@ namespace Stratis.FederatedPeg.Tests.RestClientsTests
         {
             var blockTip = new BlockTipModel(TestingValues.GetUint256(), TestingValues.GetPositiveInt(), TestingValues.GetPositiveInt());
 
-            await this.createClient(true).PushCurrentBlockTipAsync(blockTip).ConfigureAwait(false);
-
-            this.logger.Received(1).Log<object>(LogLevel.Error, 0, Arg.Any<object>(), Arg.Is<Exception>(e => e == null), Arg.Any<Func<object, Exception, string>>());
+            HttpResponseMessage result = await this.createClient(true).PushCurrentBlockTipAsync(blockTip).ConfigureAwait(false);
+            Assert.False(result.IsSuccessStatusCode);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.FederatedPeg.Tests/Utils/TestingHttpClient.cs
+++ b/src/Stratis.FederatedPeg.Tests/Utils/TestingHttpClient.cs
@@ -27,7 +27,7 @@ namespace Stratis.FederatedPeg.Tests.Utils
             object sendCall = httpMessageHandler.Protected("SendAsync", Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>());
 
             if (failingClient)
-                sendCall.ThrowsForAnyArgs(new Exception("failed"));
+                sendCall.ThrowsForAnyArgs(new HttpRequestException("failed"));
             else
                 sendCall.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 


### PR DESCRIPTION
This reverts https://github.com/stratisproject/FederatedSidechains/pull/334
Since I think that PR fixes consequence instead of source of the problem. Source of the problem is the generation of duplicated requests by another gateway. 

Instead of cache I've added 60s timeout, made sure blocks collection takes no more than around 30s, reduced max batch size from 1000 to 100.