### PR TITLE
NuGet fix

### DIFF
--- a/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
+++ b/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.3-beta" />
     <PackageReference Include="Stratis.Bitcoin.Features.SmartContracts" Version="0.0.5-beta" />
     <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.3-beta" />
+    <PackageReference Include="Stratis.SmartContracts.RuntimeObserver" Version="0.0.1-beta" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Puts the .RuntimeObserver NuGet in the same package as Stratis.Bitcoin.Features.SmartContracts.