### PR TITLE
API methods to get height closest to timestamp

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Models/ClosestHeightModel.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Models/ClosestHeightModel.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Stratis.FederatedPeg.Features.FederationGateway.Models
+{
+    public class ClosestHeightModel
+    {
+        [JsonProperty(PropertyName = "height")]
+        public int Height { get; set; }
+    }
+}

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/FederationGatewayClient.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/FederationGatewayClient.cs
@@ -16,6 +16,9 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
 
         /// <summary><see cref="FederationGatewayController.GetMaturedBlockDepositsAsync"/></summary>
         Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken));
+
+        /// <summary><see cref="FederationGatewayController.GetBlockHeightClosestToTimestamp"/></summary>
+        Task<ClosestHeightModel> GetBlockHeightClosestToTimestampAsync(uint timestamp, CancellationToken cancellation = default(CancellationToken));
     }
 
     /// <inheritdoc cref="IFederationGatewayClient"/>
@@ -36,6 +39,14 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
         public Task<List<MaturedBlockDepositsModel>> GetMaturedBlockDepositsAsync(MaturedBlockRequestModel model, CancellationToken cancellation = default(CancellationToken))
         {
             return this.SendPostRequestAsync<MaturedBlockRequestModel, List<MaturedBlockDepositsModel>>(model, FederationGatewayRouteEndPoint.GetMaturedBlockDeposits, cancellation);
+        }
+
+        /// <inheritdoc />
+        public Task<ClosestHeightModel> GetBlockHeightClosestToTimestampAsync(uint timestamp, CancellationToken cancellation = default(CancellationToken))
+        {
+            string parameters = $"{nameof(timestamp)}={timestamp}";
+
+            return this.SendGetRequestAsync<ClosestHeightModel>(FederationGatewayRouteEndPoint.GetBlockHeightClosestToTimestamp, cancellation, parameters);
         }
     }
 }

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/RestClients/RestApiClientBase.cs
@@ -48,6 +48,51 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
                 }, onRetry: OnRetry);
         }
 
+        protected async Task<HttpResponseMessage> SendGetRequestAsync(string apiMethodName, CancellationToken cancellation, string requestParameters = null)
+        {
+            string url = $"{this.endpointUrl}/{apiMethodName}";
+
+            if (requestParameters != null)
+                url += $"?{requestParameters}";
+
+            var publicationUri = new Uri(url);
+
+            HttpResponseMessage response = null;
+
+            using (HttpClient client = this.httpClientFactory.CreateClient())
+            {
+                try
+                {
+                    // Retry the following call according to the policy.
+                    await this.policy.ExecuteAsync(async token =>
+                    {
+                        this.logger.LogDebug("Sending get request to Uri '{0}'.", publicationUri);
+                        response = await client.GetAsync(publicationUri, cancellation).ConfigureAwait(false);
+                    }, cancellation);
+                }
+                catch (OperationCanceledException)
+                {
+                    this.logger.LogTrace("(-)[CANCELLED]:null");
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogError("The counter-chain daemon is not ready to receive API calls at this time ({0})", publicationUri);
+                    return new HttpResponseMessage() { ReasonPhrase = ex.Message, StatusCode = HttpStatusCode.InternalServerError };
+                }
+            }
+
+            this.logger.LogTrace("(-)[SUCCESS]");
+            return response;
+        }
+
+        protected async Task<Response> SendGetRequestAsync<Response>(string apiMethodName, CancellationToken cancellation, string requestParameters = null) where Response : class
+        {
+            HttpResponseMessage response = await this.SendGetRequestAsync(apiMethodName, cancellation, requestParameters).ConfigureAwait(false);
+
+            return await this.ParseResponseAsync<Response>(response).ConfigureAwait(false);
+        }
+
         protected async Task<HttpResponseMessage> SendPostRequestAsync<Model>(Model requestModel, string apiMethodName, CancellationToken cancellation) where Model : class
         {
             var publicationUri = new Uri($"{this.endpointUrl}/{apiMethodName}");
@@ -93,10 +138,15 @@ namespace Stratis.FederatedPeg.Features.FederationGateway.RestClients
         {
             HttpResponseMessage response = await this.SendPostRequestAsync(requestModel, apiMethodName, cancellation).ConfigureAwait(false);
 
+            return await this.ParseResponseAsync<Response>(response).ConfigureAwait(false);
+        }
+
+        private async Task<Response> ParseResponseAsync<Response>(HttpResponseMessage message) where Response : class
+        {
             // Parse response.
-            if ((response != null) && response.IsSuccessStatusCode && (response.Content != null))
+            if ((message != null) && message.IsSuccessStatusCode && (message.Content != null))
             {
-                string successJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                string successJson = await message.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (successJson != null)
                 {
                     Response responseModel = JsonConvert.DeserializeObject<Response>(successJson);

--- a/src/Stratis.FederatedPeg.Tests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/FederationGatewayControllerTests.cs
@@ -314,9 +314,9 @@ namespace Stratis.FederatedPeg.Tests
 
             JsonResult result = controller.GetBlockHeightClosestToTimestamp(targetHeader.Header.Time);
 
-            int responseHeight = JsonConvert.DeserializeObject<int>(result.Value.ToString());
+            var responseHeight = result.Value as ClosestHeightModel;
 
-            Assert.Equal(targetHeader.Height, responseHeight);
+            Assert.Equal(targetHeader.Height, responseHeight.Height);
         }
     }
 }

--- a/src/Stratis.FederatedPeg.Tests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.FederatedPeg.Tests/FederationGatewayControllerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using NBitcoin.Protocol;
+using Newtonsoft.Json;
 using NSubstitute;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Configuration;
@@ -74,6 +75,7 @@ namespace Stratis.FederatedPeg.Tests
                 this.leaderReceiver,
                 this.federationGatewaySettings,
                 this.federationWalletManager,
+                this.consensusManager,
                 this.federationManager);
 
             return controller;
@@ -236,6 +238,7 @@ namespace Stratis.FederatedPeg.Tests
                 this.leaderReceiver,
                 settings,
                 this.federationWalletManager,
+                this.consensusManager,
                 this.federationManager);
 
             IActionResult result = controller.GetInfo();
@@ -275,6 +278,7 @@ namespace Stratis.FederatedPeg.Tests
                 this.leaderReceiver,
                 settings,
                 this.federationWalletManager,
+                this.consensusManager,
                 this.federationManager);
 
             IActionResult result = controller.GetInfo();
@@ -292,6 +296,27 @@ namespace Stratis.FederatedPeg.Tests
             model.MinCoinMaturity.Should().Be(1);
             model.MinimumDepositConfirmations.Should().Be(1);
             model.MultisigPublicKey.Should().Be(multisigPubKey);
+        }
+
+        [Fact]
+        public void GetBlockHeightClosestToTimestampTest()
+        {
+            FederationGatewayController controller = this.CreateController();
+
+            List<ChainedHeader> headers = ChainedHeadersHelper.CreateConsecutiveHeaders(1000);
+
+            for (int i = 0; i < headers.Count; i++)
+                headers[i].Header.Time = (uint)(i * 3);
+
+            this.consensusManager.Tip.Returns(headers.Last());
+
+            ChainedHeader targetHeader = headers[500];
+
+            JsonResult result = controller.GetBlockHeightClosestToTimestamp(targetHeader.Header.Time);
+
+            int responseHeight = JsonConvert.DeserializeObject<int>(result.Value.ToString());
+
+            Assert.Equal(targetHeader.Height, responseHeight);
         }
     }
 }


### PR DESCRIPTION
Added API methods to controller and client to request block height that is closed to given timestamp. 

This is later will be needed to initialize `NextMatureDepositHeight` in `CrossChainTransferStore` so the store syncs not from the 1st block but from a block generated at the same time when genesis block of current chain was created.

It is not possible to do it now because `CrossChainTransferStore` requires refactoring in order to allow initialization that requires API call to another node. 

related to https://github.com/stratisproject/FederatedSidechains/issues/268

