### PR TITLE
Clean up warning and associated code-style

### DIFF
--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -231,14 +231,14 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             if (!isFederationActive)
             {
                 var warning =
-                                                    "=============================================".PadLeft(10,'=')
-                           + Environment.NewLine
-                           + Environment.NewLine +  "Federation node not enabled. You will not be able to sign transactions until you enable it."
-                           + Environment.NewLine + $"If not done previously, please enable your federation node using "
-                           + Environment.NewLine + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}"
-                           + Environment.NewLine
-                           + Environment.NewLine + $"============================================".PadLeft(10, '=')
-                           + Environment.NewLine;
+                      Environment.NewLine + "".PadRight(59, '=') + " W A R N I N G " + "".PadRight(59, '=')
+                    + Environment.NewLine
+                    + Environment.NewLine +  "This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it."
+                    + Environment.NewLine + $"If not done previously, please enable your federation node using "
+                    + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}."
+                    + Environment.NewLine
+                    + Environment.NewLine + "".PadRight(133, '=')
+                    + Environment.NewLine;
                 benchLog.AppendLine(warning);
             }
 

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -233,7 +233,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
                 var warning =
                       Environment.NewLine + "".PadRight(59, '=') + " W A R N I N G " + "".PadRight(59, '=')
                     + Environment.NewLine
-                    + Environment.NewLine +  "This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it."
+                    + Environment.NewLine + "This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it."
                     + Environment.NewLine + $"If not done previously, please enable your federation node using " + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}."
                     + Environment.NewLine
                     + Environment.NewLine + "".PadRight(133, '=')

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -234,8 +234,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
                       Environment.NewLine + "".PadRight(59, '=') + " W A R N I N G " + "".PadRight(59, '=')
                     + Environment.NewLine
                     + Environment.NewLine +  "This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it."
-                    + Environment.NewLine + $"If not done previously, please enable your federation node using "
-                    + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}."
+                    + Environment.NewLine + $"If not done previously, please enable your federation node using " + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}."
                     + Environment.NewLine
                     + Environment.NewLine + "".PadRight(133, '=')
                     + Environment.NewLine;

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -227,18 +227,17 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
                                 + " Federation Status: " + (isFederationActive ? "Active" : "Inactive"));
             benchLog.AppendLine();
 
-            var apiSettings = (ApiSettings)this.fullNode.Services.ServiceProvider.GetService(typeof(ApiSettings));
             if (!isFederationActive)
             {
-                var warning =
-                      Environment.NewLine + "".PadRight(59, '=') + " W A R N I N G " + "".PadRight(59, '=')
-                    + Environment.NewLine
-                    + Environment.NewLine + "This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it."
-                    + Environment.NewLine + $"If not done previously, please enable your federation node using " + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}."
-                    + Environment.NewLine
-                    + Environment.NewLine + "".PadRight(133, '=')
-                    + Environment.NewLine;
-                benchLog.AppendLine(warning);
+                var apiSettings = (ApiSettings)this.fullNode.Services.ServiceProvider.GetService(typeof(ApiSettings));
+
+                benchLog.AppendLine("".PadRight(59, '=') + " W A R N I N G " + "".PadRight(59, '='));
+                benchLog.AppendLine();
+                benchLog.AppendLine("This federation node is not enabled. You will not be able to store or participate in signing of transactions until you enable it.");
+                benchLog.AppendLine("If not done previously, please enable your federation node using " + $"{apiSettings.ApiUri}/api/FederationWallet/{FederationWalletRouteEndPoint.EnableFederation}.");
+                benchLog.AppendLine();
+                benchLog.AppendLine("".PadRight(133, '='));
+                benchLog.AppendLine();
             }
 
             // Display recent withdrawals (if any).

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/FederationGatewayFeature.cs
@@ -37,6 +37,8 @@ using Stratis.FederatedPeg.Features.FederationGateway.TargetChain;
 using Stratis.FederatedPeg.Features.FederationGateway.Wallet;
 using Stratis.FederatedPeg.Features.FederationGateway.RestClients;
 using Stratis.Bitcoin.Features.MemoryPool;
+using System.Collections.Generic;
+using Stratis.FederatedPeg.Features.FederationGateway.Models;
 
 [assembly: InternalsVisibleTo("Stratis.FederatedPeg.Features.FederationGateway.Tests")]
 [assembly: InternalsVisibleTo("Stratis.FederatedPeg.IntegrationTests")]
@@ -88,6 +90,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
 
         private readonly IMaturedBlocksSyncManager maturedBlocksSyncManager;
 
+        private readonly IWithdrawalHistoryProvider withdrawalHistoryProvider;
+
         private readonly ILogger logger;
 
         public FederationGatewayFeature(
@@ -108,7 +112,8 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             IPartialTransactionRequester partialTransactionRequester,
             IFederationGatewayClient federationGatewayClient,
             MempoolManager mempoolManager,
-            IMaturedBlocksSyncManager maturedBlocksSyncManager)
+            IMaturedBlocksSyncManager maturedBlocksSyncManager,
+            IWithdrawalHistoryProvider withdrawalHistoryProvider)
         {
             this.loggerFactory = loggerFactory;
             this.signals = signals;
@@ -127,6 +132,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             this.federationGatewayClient = federationGatewayClient;
             this.mempoolManager = mempoolManager;
             this.maturedBlocksSyncManager = maturedBlocksSyncManager;
+            this.withdrawalHistoryProvider = withdrawalHistoryProvider;
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
 
@@ -237,29 +243,12 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
             }
 
             // Display recent withdrawals (if any).
-            IWithdrawal[] withdrawals = this.federationWalletManager.GetWithdrawals().Take(5).ToArray();
-            if (withdrawals.Length > 0)
+            List<WithdrawalModel> withdrawals = this.withdrawalHistoryProvider.GetHistory(5);
+            if (withdrawals.Count > 0)
             {
-                benchLog.AppendLine("-- Recent Withdrawals --");
-                ICrossChainTransfer[] transfers = this.crossChainTransferStore.GetAsync(withdrawals.Select(w => w.DepositId).ToArray()).GetAwaiter().GetResult().ToArray();
-                for (int i = 0; i < withdrawals.Length; i++)
-                {
-                    ICrossChainTransfer transfer = transfers[i];
-                    IWithdrawal withdrawal = withdrawals[i];
-                    string line = withdrawal.GetInfo() + " Status=" + transfer?.Status;
-                    switch (transfer?.Status)
-                    {
-                        case CrossChainTransferStatus.FullySigned:
-                            if (this.mempoolManager.InfoAsync(withdrawal.Id).GetAwaiter().GetResult() != null)
-                                line += "+InMempool";
-                            break;
-                        case CrossChainTransferStatus.Partial:
-                            line += " (" + transfer.GetSignatureCount(this.network) + "/" + this.federationGatewaySettings.MultiSigM + ")";
-                            break;
-                    }
-
-                    benchLog.AppendLine(line);
-                }
+                benchLog.AppendLine("--- Recent Withdrawals ---");
+                foreach (WithdrawalModel withdrawal in withdrawals)
+                    benchLog.AppendLine(withdrawal.ToString());
                 benchLog.AppendLine();
             }
 
@@ -340,6 +329,7 @@ namespace Stratis.FederatedPeg.Features.FederationGateway
                         services.AddSingleton<IPartialTransactionRequester, PartialTransactionRequester>();
                         services.AddSingleton<IFederationGatewayClient, FederationGatewayClient>();
                         services.AddSingleton<IMaturedBlocksSyncManager, MaturedBlocksSyncManager>();
+                        services.AddSingleton<IWithdrawalHistoryProvider, WithdrawalHistoryProvider>();
                     });
             });
             return fullNodeBuilder;

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IWithdrawalHistoryProvider.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Interfaces/IWithdrawalHistoryProvider.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Stratis.FederatedPeg.Features.FederationGateway.Models;
+
+namespace Stratis.FederatedPeg.Features.FederationGateway.Interfaces
+{
+    public interface IWithdrawalHistoryProvider
+    {
+        List<WithdrawalModel> GetHistory(int maximumEntriesToReturn);
+    }
+}

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/Models/WithdrawalModel.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/Models/WithdrawalModel.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
+using Stratis.FederatedPeg.Features.FederationGateway.TargetChain;
+
+namespace Stratis.FederatedPeg.Features.FederationGateway.Models
+{
+    public class WithdrawalModel
+    {
+        [JsonConverter(typeof(ConcreteConverter<Withdrawal>))]
+        public IWithdrawal withdrawal { get; set; }
+
+        public string TransferStatus { get; set; }
+
+        public override string ToString()
+        {
+            return this.withdrawal.GetInfo() + " Status=" + this.TransferStatus;
+        }
+    }
+}

--- a/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalHistoryProvider.cs
+++ b/src/Stratis.FederatedPeg.Features.FederationGateway/TargetChain/WithdrawalHistoryProvider.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.FederatedPeg.Features.FederationGateway.Interfaces;
+using Stratis.FederatedPeg.Features.FederationGateway.Models;
+
+namespace Stratis.FederatedPeg.Features.FederationGateway.TargetChain
+{
+    public class WithdrawalHistoryProvider : IWithdrawalHistoryProvider
+    {
+        private readonly Network network;
+        private readonly IFederationGatewaySettings federationGatewaySettings;
+        private readonly IFederationWalletManager federationWalletManager;
+        private readonly ICrossChainTransferStore crossChainTransferStore;
+        private readonly MempoolManager mempoolManager;
+
+        /// <summary>
+        /// The <see cref="WithdrawalHistoryProvider"/> constructor.
+        /// </summary>
+        /// <param name="network">Network we are running on.</param>
+        /// <param name="federationGatewaySettings">Federation settings providing access to number of signatures required.</param>
+        /// <param name="federationWalletManager">Wallet manager which provides access to the wallet.</param>
+        /// <param name="crossChainTransferStore">Store which provides access to the statuses.</param>
+        /// <param name="mempoolManager">Mempool which provides information about transactions in the mempool.</param>
+        public WithdrawalHistoryProvider(
+            Network network,
+            IFederationGatewaySettings federationGatewaySettings,
+            IFederationWalletManager federationWalletManager,
+            ICrossChainTransferStore crossChainTransferStore,
+            MempoolManager mempoolManager)
+        {
+            this.network = network;
+            this.federationGatewaySettings = federationGatewaySettings;
+            this.federationWalletManager = federationWalletManager;
+            this.crossChainTransferStore = crossChainTransferStore;
+            this.mempoolManager = mempoolManager;
+        }
+
+        /// <summary>
+        /// Get the history of withdrawals and statuses.
+        /// </summary>
+        /// <param name="maximumEntriesToReturn">The maximum number of entries to return.</param>
+        /// <returns>A <see cref="WithdrawalModel"/> object containing a history of withdrawals and statuses.</returns>
+        public List<WithdrawalModel> GetHistory(int maximumEntriesToReturn)
+        {
+            var result = new List<WithdrawalModel>();
+            IWithdrawal[] withdrawals = this.federationWalletManager.GetWithdrawals().Take(maximumEntriesToReturn).ToArray();
+
+            if (withdrawals.Length > 0)
+            {
+                ICrossChainTransfer[] transfers = this.crossChainTransferStore.GetAsync(withdrawals.Select(w => w.DepositId).ToArray()).GetAwaiter().GetResult().ToArray();
+
+                for (int i = 0; i < withdrawals.Length; i++)
+                {
+                    ICrossChainTransfer transfer = transfers[i];
+                    var model = new WithdrawalModel();
+                    model.withdrawal = withdrawals[i];
+                    string status = transfer?.Status.ToString();
+                    switch (transfer?.Status)
+                    {
+                        case CrossChainTransferStatus.FullySigned:
+                            if (this.mempoolManager.InfoAsync(model.withdrawal.Id).GetAwaiter().GetResult() != null)
+                                status += "+InMempool";
+                            break;
+                        case CrossChainTransferStatus.Partial:
+                            status += " (" + transfer.GetSignatureCount(this.network) + "/" + this.federationGatewaySettings.MultiSigM + ")";
+                            break;
+                    }
+
+                    model.TransferStatus = status;
+                    result.Add(model);
+                }
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the warning a bit more visible, fixes extraneous indentation and removes unnecessary '===...' in the code.

![image](https://user-images.githubusercontent.com/29645989/50325323-3eb70500-0538-11e9-82ff-dcc35a651b2f.png)
